### PR TITLE
LIIKUNTA-31 | Add top navigation

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,7 @@
+const path = require("path");
+
+module.exports = {
+  sassOptions: {
+    includePaths: [path.join(__dirname, "src/styles")],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@types/jest": "^26.0.23",
+    "hds-design-tokens": "^1.0.0",
     "hds-react": "^1.0.0",
     "next": "10.2.0",
     "react": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@types/jest": "^26.0.23",
+    "hds-react": "^1.0.0",
     "next": "10.2.0",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "hds-react": "^1.0.0",
     "next": "10.2.0",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "sass": "^1.32.12"
   },
   "devDependencies": {
     "@testing-library/dom": "^7.30.4",

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,6 @@
-const MAIN_CONTENT_ID = "main-content";
+import Navigation from "../navigation/Navigation";
 
-const Navigation = () => <header>Navigation</header>;
+const MAIN_CONTENT_ID = "main-content";
 
 const Footer = () => <footer>Footer</footer>;
 
@@ -11,7 +11,7 @@ type Props = {
 function AppLayout({ children }: Props) {
   return (
     <>
-      <Navigation />
+      <Navigation mainContentId={MAIN_CONTENT_ID} />
       <main id={MAIN_CONTENT_ID}>{children}</main>
       <Footer />
     </>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,4 @@
 import Navigation from "../navigation/Navigation";
-import { MenuItem } from "./getLayoutData";
 import { LayoutComponentProps } from "./types";
 import styles from "./layout.module.scss";
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,21 @@
+const MAIN_CONTENT_ID = "main-content";
+
+const Navigation = () => <header>Navigation</header>;
+
+const Footer = () => <footer>Footer</footer>;
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function AppLayout({ children }: Props) {
+  return (
+    <>
+      <Navigation />
+      <main id={MAIN_CONTENT_ID}>{children}</main>
+      <Footer />
+    </>
+  );
+}
+
+export default AppLayout;

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,4 +1,5 @@
 import Navigation from "../navigation/Navigation";
+import styles from "./layout.module.scss";
 
 const MAIN_CONTENT_ID = "main-content";
 
@@ -10,11 +11,11 @@ type Props = {
 
 function AppLayout({ children }: Props) {
   return (
-    <>
+    <div className={styles.Layout}>
       <Navigation mainContentId={MAIN_CONTENT_ID} />
       <main id={MAIN_CONTENT_ID}>{children}</main>
       <Footer />
-    </>
+    </div>
   );
 }
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,18 +1,19 @@
 import Navigation from "../navigation/Navigation";
+import { MenuItem } from "./getLayoutData";
+import { LayoutComponentProps } from "./types";
 import styles from "./layout.module.scss";
 
 const MAIN_CONTENT_ID = "main-content";
 
 const Footer = () => <footer>Footer</footer>;
 
-type Props = {
-  children: React.ReactNode;
-};
-
-function AppLayout({ children }: Props) {
+function AppLayout({ children, navigationItems }: LayoutComponentProps) {
   return (
     <div className={styles.Layout}>
-      <Navigation mainContentId={MAIN_CONTENT_ID} />
+      <Navigation
+        mainContentId={MAIN_CONTENT_ID}
+        navigationItems={navigationItems}
+      />
       <main id={MAIN_CONTENT_ID}>{children}</main>
       <Footer />
     </div>

--- a/src/components/layout/getLayoutData.ts
+++ b/src/components/layout/getLayoutData.ts
@@ -1,0 +1,38 @@
+import { GetStaticPropsContext } from "next";
+
+import { NavigationItem } from "../../types";
+import menuItems from "./tmp/menuItems";
+
+type MenuItem = {
+  id: string;
+  order: number;
+  path: string;
+  target: string;
+  title: string;
+  url: string;
+};
+
+type LayoutData = {
+  languages: Array<{
+    id: string;
+    name: string;
+    slug: string;
+    code: string;
+    locale: string;
+  }>;
+  navigationItems: NavigationItem[];
+};
+
+async function getLayoutData(
+  context: GetStaticPropsContext
+): Promise<LayoutData> {
+  const sortedMenuItems = [...menuItems].sort((a, b) => a.order - b.order);
+  const navigationItems = sortedMenuItems.map(({ order, ...rest }) => rest);
+
+  return {
+    languages: [],
+    navigationItems,
+  };
+}
+
+export default getLayoutData;

--- a/src/components/layout/getLayoutData.ts
+++ b/src/components/layout/getLayoutData.ts
@@ -3,15 +3,6 @@ import { GetStaticPropsContext } from "next";
 import { NavigationItem } from "../../types";
 import menuItems from "./tmp/menuItems";
 
-type MenuItem = {
-  id: string;
-  order: number;
-  path: string;
-  target: string;
-  title: string;
-  url: string;
-};
-
 type LayoutData = {
   languages: Array<{
     id: string;

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -1,0 +1,26 @@
+@use "breakpoints";
+@import "variables";
+
+.Layout {
+  --spacing: #{$spacing-layout-2-xs};
+  --content-width: calc(var(--breakpoint-xl) - 2 * #{$spacing-layout-xs});
+
+  display: grid;
+  // Set a three column layout where the middle column is the content column
+  // that has a max width of --content-width and two whitespace columns with a
+  // mininum width of --spacing.
+  grid-template-columns:
+    minmax(var(--spacing), auto)
+    minmax(auto, var(--content-width))
+    minmax(var(--spacing), auto);
+  grid-template-rows: auto;
+
+  & > * {
+    // Force child element into the content column
+    grid-column: 2;
+  }
+
+  @include breakpoints.respond-above(m) {
+    --spacing: #{$spacing-layout-xs};
+  }
+}

--- a/src/components/layout/tmp/menuItems.ts
+++ b/src/components/layout/tmp/menuItems.ts
@@ -1,0 +1,34 @@
+export default [
+  {
+    id: "1",
+    order: 0,
+    path: "/haku",
+    target: "",
+    title: "Haku",
+    url: "/haku",
+  },
+  {
+    id: "3",
+    order: 2,
+    path: "/liikuntatunnit",
+    target: "",
+    title: "Liikuntatunnit",
+    url: "/liikuntatunnit",
+  },
+  {
+    id: "2",
+    order: 1,
+    path: "/liikuntapaikat",
+    target: "",
+    title: "Liikuntapaikat",
+    url: "/liikuntapaikat",
+  },
+  {
+    id: "4",
+    order: 3,
+    path: "/ryhmat",
+    target: "",
+    title: "Ryhmät",
+    url: "/ryhmat",
+  },
+];

--- a/src/components/layout/tmp/menuItems.ts
+++ b/src/components/layout/tmp/menuItems.ts
@@ -1,4 +1,13 @@
-export default [
+type MenuItem = {
+  id: string;
+  order: number;
+  path: string;
+  target: string;
+  title: string;
+  url: string;
+};
+
+const menuItems: MenuItem[] = [
   {
     id: "1",
     order: 0,
@@ -32,3 +41,5 @@ export default [
     url: "/ryhmat",
   },
 ];
+
+export default menuItems;

--- a/src/components/layout/types.ts
+++ b/src/components/layout/types.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { NavigationItem } from "../../types";
 
 export type LayoutComponentProps = {

--- a/src/components/layout/types.ts
+++ b/src/components/layout/types.ts
@@ -1,0 +1,8 @@
+import { NavigationItem } from "../../types";
+
+export type LayoutComponentProps = {
+  children: React.ReactNode;
+  navigationItems: NavigationItem[];
+};
+
+export type LayoutComponent = React.ComponentType<LayoutComponentProps>;

--- a/src/components/meta/AppMeta.tsx
+++ b/src/components/meta/AppMeta.tsx
@@ -1,0 +1,15 @@
+import Head from "next/head";
+
+function AppMeta() {
+  return (
+    <Head>
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="Liikunta Helsinki" />
+
+      {/* Force summary card */}
+      <meta name="twitter:card" content="summary" />
+    </Head>
+  );
+}
+
+export default AppMeta;

--- a/src/components/meta/PageMeta.tsx
+++ b/src/components/meta/PageMeta.tsx
@@ -1,0 +1,25 @@
+import Head from "next/head";
+
+export type Props = {
+  // Title of page, required for accessibility: pages should have unique titles
+  // so that screen reader users are able to determine when the current page is
+  // changed.
+  title: string;
+  description?: string | null;
+  image?: string | null;
+};
+
+function PageMeta({ title, description, image }: Props) {
+  return (
+    <Head>
+      <title>{title}</title>
+      {description && <meta name="description" content={description} />}
+
+      <meta property="og:title" content={title} />
+      {description && <meta property="og:description" content={description} />}
+      {image && <meta property="og:image" content={image} />}
+    </Head>
+  );
+}
+
+export default PageMeta;

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -20,52 +20,52 @@ function Navigation({ mainContentId }: Props) {
         <HDSNavigation.Item label="Liikuntapaikat" />
         <HDSNavigation.Item label="Liikuntatunnit" />
         <HDSNavigation.Item label="Ryhmät" />
-        <HDSNavigation.Actions>
-          <HDSNavigation.User
-            authenticated={true}
-            buttonAriaLabel=""
-            label=""
-            onSignIn={() => {}}
-            userName="Liza Liikkuja"
-          >
-            <HDSNavigation.Item
-              as="a"
-              href="#"
-              label="Link"
-              onClick={() => {}}
-              variant="secondary"
-            />
-            <HDSNavigation.Item
-              as="a"
-              href="#"
-              icon={<IconSignout aria-hidden />}
-              label="Sign out"
-              onClick={() => {}}
-              variant="supplementary"
-            />
-          </HDSNavigation.User>
-          <HDSNavigation.LanguageSelector label="FI">
-            <HDSNavigation.Item
-              as="a"
-              href="#"
-              label="Suomeksi"
-              onClick={() => {}}
-            />
-            <HDSNavigation.Item
-              as="a"
-              href="#"
-              label="På svenska"
-              onClick={() => {}}
-            />
-            <HDSNavigation.Item
-              as="a"
-              href="#"
-              label="In English"
-              onClick={() => {}}
-            />
-          </HDSNavigation.LanguageSelector>
-        </HDSNavigation.Actions>
       </HDSNavigation.Row>
+      <HDSNavigation.Actions>
+        <HDSNavigation.User
+          authenticated={true}
+          buttonAriaLabel=""
+          label=""
+          onSignIn={() => {}}
+          userName="Liza Liikkuja"
+        >
+          <HDSNavigation.Item
+            as="a"
+            href="#"
+            label="Link"
+            onClick={() => {}}
+            variant="secondary"
+          />
+          <HDSNavigation.Item
+            as="a"
+            href="#"
+            icon={<IconSignout aria-hidden />}
+            label="Sign out"
+            onClick={() => {}}
+            variant="supplementary"
+          />
+        </HDSNavigation.User>
+        <HDSNavigation.LanguageSelector label="FI">
+          <HDSNavigation.Item
+            as="a"
+            href="#"
+            label="Suomeksi"
+            onClick={() => {}}
+          />
+          <HDSNavigation.Item
+            as="a"
+            href="#"
+            label="På svenska"
+            onClick={() => {}}
+          />
+          <HDSNavigation.Item
+            as="a"
+            href="#"
+            label="In English"
+            onClick={() => {}}
+          />
+        </HDSNavigation.LanguageSelector>
+      </HDSNavigation.Actions>
     </HDSNavigation>
   );
 }

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,0 +1,74 @@
+import { Navigation as HDSNavigation, IconSignout } from "hds-react";
+
+type Props = {
+  mainContentId: string;
+};
+
+function Navigation({ mainContentId }: Props) {
+  return (
+    <HDSNavigation
+      // Use yellow colour
+      theme={{
+        "--header-background-color": "var(--color-engel)",
+      }}
+      title="Liikunta Helsinki"
+      menuToggleAriaLabel="menu"
+      skipTo={`#${mainContentId}`}
+      skipToContentLabel="Siirry suoraan sisältöön"
+    >
+      <HDSNavigation.Row variant="inline">
+        <HDSNavigation.Item label="Haku" active />
+        <HDSNavigation.Item label="Liikuntapaikat" />
+        <HDSNavigation.Item label="Liikuntatunnit" />
+        <HDSNavigation.Item label="Ryhmät" />
+        <HDSNavigation.Actions>
+          <HDSNavigation.User
+            authenticated={true}
+            buttonAriaLabel=""
+            label=""
+            onSignIn={() => {}}
+            userName="Liza Liikkuja"
+          >
+            <HDSNavigation.Item
+              as="a"
+              href="#"
+              label="Link"
+              onClick={() => {}}
+              variant="secondary"
+            />
+            <HDSNavigation.Item
+              as="a"
+              href="#"
+              icon={<IconSignout aria-hidden />}
+              label="Sign out"
+              onClick={() => {}}
+              variant="supplementary"
+            />
+          </HDSNavigation.User>
+          <HDSNavigation.LanguageSelector label="FI">
+            <HDSNavigation.Item
+              as="a"
+              href="#"
+              label="Suomeksi"
+              onClick={() => {}}
+            />
+            <HDSNavigation.Item
+              as="a"
+              href="#"
+              label="På svenska"
+              onClick={() => {}}
+            />
+            <HDSNavigation.Item
+              as="a"
+              href="#"
+              label="In English"
+              onClick={() => {}}
+            />
+          </HDSNavigation.LanguageSelector>
+        </HDSNavigation.Actions>
+      </HDSNavigation.Row>
+    </HDSNavigation>
+  );
+}
+
+export default Navigation;

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,12 +1,24 @@
+import React, { ReactElement } from "react";
 import { Navigation as HDSNavigation, IconSignout } from "hds-react";
+import NextLink from "next/link";
 
+import { NavigationItem } from "../../types";
 import styles from "./navigation.module.scss";
+
+const Link = ({ href, children, ...rest }) => {
+  return (
+    <NextLink href={href}>
+      <a {...rest}>{children}</a>
+    </NextLink>
+  );
+};
 
 type Props = {
   mainContentId: string;
+  navigationItems: NavigationItem[];
 };
 
-function Navigation({ mainContentId }: Props) {
+function Navigation({ mainContentId, navigationItems }: Props) {
   return (
     <HDSNavigation
       className={styles.Navigation}
@@ -16,10 +28,14 @@ function Navigation({ mainContentId }: Props) {
       skipToContentLabel="Siirry suoraan sisältöön"
     >
       <HDSNavigation.Row variant="inline">
-        <HDSNavigation.Item label="Haku" active />
-        <HDSNavigation.Item label="Liikuntapaikat" />
-        <HDSNavigation.Item label="Liikuntatunnit" />
-        <HDSNavigation.Item label="Ryhmät" />
+        {navigationItems.map((navigationItem) => (
+          <HDSNavigation.Item
+            key={navigationItem.id}
+            as={Link}
+            label={navigationItem.title}
+            href={navigationItem.url}
+          />
+        ))}
       </HDSNavigation.Row>
       <HDSNavigation.Actions>
         <HDSNavigation.User

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,5 +1,7 @@
 import { Navigation as HDSNavigation, IconSignout } from "hds-react";
 
+import styles from "./navigation.module.scss";
+
 type Props = {
   mainContentId: string;
 };
@@ -7,10 +9,7 @@ type Props = {
 function Navigation({ mainContentId }: Props) {
   return (
     <HDSNavigation
-      // Use yellow colour
-      theme={{
-        "--header-background-color": "var(--color-engel)",
-      }}
+      className={styles.Navigation}
       title="Liikunta Helsinki"
       menuToggleAriaLabel="menu"
       skipTo={`#${mainContentId}`}

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -1,9 +1,12 @@
-import React, { ReactElement } from "react";
+import React from "react";
 import { Navigation as HDSNavigation, IconSignout } from "hds-react";
 import NextLink from "next/link";
 
 import { NavigationItem } from "../../types";
 import styles from "./navigation.module.scss";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
 
 const Link = ({ href, children, ...rest }) => {
   return (
@@ -42,14 +45,14 @@ function Navigation({ mainContentId, navigationItems }: Props) {
           authenticated={true}
           buttonAriaLabel=""
           label=""
-          onSignIn={() => {}}
+          onSignIn={noop}
           userName="Liza Liikkuja"
         >
           <HDSNavigation.Item
             as="a"
             href="#"
             label="Link"
-            onClick={() => {}}
+            onClick={noop}
             variant="secondary"
           />
           <HDSNavigation.Item
@@ -57,28 +60,23 @@ function Navigation({ mainContentId, navigationItems }: Props) {
             href="#"
             icon={<IconSignout aria-hidden />}
             label="Sign out"
-            onClick={() => {}}
+            onClick={noop}
             variant="supplementary"
           />
         </HDSNavigation.User>
         <HDSNavigation.LanguageSelector label="FI">
-          <HDSNavigation.Item
-            as="a"
-            href="#"
-            label="Suomeksi"
-            onClick={() => {}}
-          />
+          <HDSNavigation.Item as="a" href="#" label="Suomeksi" onClick={noop} />
           <HDSNavigation.Item
             as="a"
             href="#"
             label="På svenska"
-            onClick={() => {}}
+            onClick={noop}
           />
           <HDSNavigation.Item
             as="a"
             href="#"
             label="In English"
-            onClick={() => {}}
+            onClick={noop}
           />
         </HDSNavigation.LanguageSelector>
       </HDSNavigation.Actions>

--- a/src/components/navigation/navigation.module.scss
+++ b/src/components/navigation/navigation.module.scss
@@ -1,0 +1,7 @@
+.Navigation {
+  // Apply yellow theme for Navigation.
+  // This approach is used instead of the prop in the <Navigation /> component
+  // because it results in classNames which are not stable between the server
+  // and client.
+  --header-background-color: var(--color-engel) !important;
+}

--- a/src/components/navigation/navigation.module.scss
+++ b/src/components/navigation/navigation.module.scss
@@ -1,7 +1,15 @@
+@use "breakpoints";
+
 .Navigation {
   // Apply yellow theme for Navigation.
   // This approach is used instead of the prop in the <Navigation /> component
   // because it results in classNames which are not stable between the server
   // and client.
   --header-background-color: var(--color-engel) !important;
+
+  // Span all columns
+  grid-column: 1 / -1 !important;
+  // Unset width so that navigation does not break the application's grid
+  // layout.
+  width: unset;
 }

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -1,16 +1,23 @@
 import DefaultLayout from "../layout/Layout";
 import PageMeta, { Props as PageMetaProps } from "../meta/PageMeta";
+import { LayoutComponent } from "../layout/types";
 
 type Props = PageMetaProps & {
-  layout?: (props: { children: React.ReactNode }) => JSX.Element;
   children: React.ReactNode;
+  layoutComponent?: LayoutComponent;
+  layout: React.ComponentProps<LayoutComponent>;
 };
 
-function Page({ layout: Layout = DefaultLayout, children, ...rest }: Props) {
+function Page({
+  children,
+  layout,
+  layoutComponent: Layout = DefaultLayout,
+  ...rest
+}: Props) {
   return (
     <>
       <PageMeta {...rest} />
-      <Layout>{children}</Layout>
+      <Layout {...layout}>{children}</Layout>
     </>
   );
 }

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -1,0 +1,18 @@
+import DefaultLayout from "../layout/Layout";
+import PageMeta, { Props as PageMetaProps } from "../meta/PageMeta";
+
+type Props = PageMetaProps & {
+  layout?: (props: { children: React.ReactNode }) => JSX.Element;
+  children: React.ReactNode;
+};
+
+function Page({ layout: Layout = DefaultLayout, children, ...rest }: Props) {
+  return (
+    <>
+      <PageMeta {...rest} />
+      <Layout>{children}</Layout>
+    </>
+  );
+}
+
+export default Page;

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import DefaultLayout from "../layout/Layout";
 import PageMeta, { Props as PageMetaProps } from "../meta/PageMeta";
 import { LayoutComponent } from "../layout/types";

--- a/src/components/page/getPageData.ts
+++ b/src/components/page/getPageData.ts
@@ -1,0 +1,16 @@
+import { GetStaticPropsContext } from "next";
+
+import { InferDataGetterResult } from "../../types";
+import getLayoutData from "../layout/getLayoutData";
+
+type PageData = {
+  layout: InferDataGetterResult<typeof getLayoutData>;
+};
+
+async function getPageData(context: GetStaticPropsContext): Promise<PageData> {
+  return {
+    layout: await getLayoutData(context),
+  };
+}
+
+export default getPageData;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import type { AppProps } from "next/app";
 
 import AppMeta from "../components/meta/AppMeta";
-import "../styles/globals.css";
+import "../styles/globals.scss";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,15 @@
 import type { AppProps } from "next/app";
 
+import AppMeta from "../components/meta/AppMeta";
 import "../styles/globals.css";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <AppMeta />
+      <Component {...pageProps} />
+    </>
+  );
 }
 
 export default MyApp;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,22 @@
-import Page from "../components/page/Page";
+import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 
-export default function Home() {
+import Page from "../components/page/Page";
+import getPageData from "../components/page/getPageData";
+
+export default function Home({
+  page,
+}: InferGetStaticPropsType<typeof getStaticProps>) {
   return (
-    <Page title="Liikunta-Helsinki" description="Liikunta-helsinki">
+    <Page title="Liikunta-Helsinki" description="Liikunta-helsinki" {...page}>
       <h1>Liikunta-Helsinki</h1>
     </Page>
   );
+}
+
+export async function getStaticProps(context: GetStaticPropsContext) {
+  return {
+    props: {
+      page: await getPageData(context),
+    },
+  };
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,9 @@
-import Head from "next/head";
+import Page from "../components/page/Page";
 
 export default function Home() {
   return (
-    <div>
-      <Head>
-        <title>Liikunta-helsinki</title>
-        <meta name="description" content="Liikunta-helsinki" />
-      </Head>
-      <main>
-        <h1>Liikunta-Helsinki</h1>
-      </main>
-    </div>
+    <Page title="Liikunta-Helsinki" description="Liikunta-helsinki">
+      <h1>Liikunta-Helsinki</h1>
+    </Page>
   );
 }

--- a/src/styles/breakpoints.scss
+++ b/src/styles/breakpoints.scss
@@ -1,0 +1,27 @@
+@import "variables";
+
+$breakpoints: (
+  xs: $breakpoint-xs,
+  s: $breakpoint-s,
+  m: $breakpoint-m,
+  l: $breakpoint-l,
+  xl: $breakpoint-xl,
+);
+
+@mixin respond-above($breakpoint) {
+  // If the breakpoint exists in the map.
+  @if map-has-key($breakpoints, $breakpoint) {
+    // Get the breakpoint value.
+    $breakpoint-value: map-get($breakpoints, $breakpoint);
+
+    // Write the media query.
+    @media (min-width: $breakpoint-value) {
+      @content;
+    }
+
+    // If the breakpoint doesn't exist in the map.
+  } @else {
+    // Log a warning.
+    @warn 'Invalid breakpoint: #{$breakpoint}.';
+  }
+}

--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,0 +1,93 @@
+@charset "utf-8";
+
+// Import Helsinki font files here. For licencing reasons font files are not publicly shared.
+@font-face {
+  font-family: "HelsinkiGrotesk";
+  font-display: swap;
+  src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/565d73a693abe0776c801607ac28f0bf.woff")
+    format("woff");
+  font-weight: 400;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+@font-face {
+  font-family: "HelsinkiGrotesk";
+  font-display: swap;
+  src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/5bb29e3b7b1d3ef30121229bbe67c3e1.woff")
+    format("woff");
+  font-weight: 400;
+  font-style: italic;
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: "HelsinkiGrotesk";
+  font-display: swap;
+  src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/7c46f288e8133b87e6b12b45dac71865.woff")
+    format("woff");
+  font-weight: 500;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: "HelsinkiGrotesk";
+  font-display: swap;
+  src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/e62dc97e83a385e4d8cdc939cf1e4213.woff")
+    format("woff");
+  font-weight: 500;
+  font-style: italic;
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: "HelsinkiGrotesk";
+  font-display: swap;
+  src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/533af26cf28d7660f24c2884d3c27eac.woff")
+    format("woff");
+  font-weight: 700;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+@font-face {
+  font-family: "HelsinkiGrotesk";
+  font-display: swap;
+  src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/20d494430c87e15e194932b729d48270.woff")
+    format("woff");
+  font-weight: 700;
+  font-style: italic;
+  text-rendering: optimizeLegibility;
+}
+
+@font-face {
+  font-family: "HelsinkiGrotesk";
+  font-display: swap;
+  src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/a50a1bd245ce63abcc0d1da80ff790d2.woff")
+    format("woff");
+  font-weight: 900;
+  font-style: normal;
+  text-rendering: optimizeLegibility;
+}
+@font-face {
+  font-family: "HelsinkiGrotesk";
+  font-display: swap;
+  src: url("https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/62a1781d8b396fbb025b0552cf6304d2.woff")
+    format("woff");
+  font-weight: 900;
+  font-style: italic;
+  text-rendering: optimizeLegibility;
+}
+
+$hel-grotesk: "HelsinkiGrotesk", Arial, -apple-system, BlinkMacSystemFont,
+  "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
+  "Droid Sans", "Helvetica Neue", sans-serif;
+
+// Application font:
+$font-family-sans-serif: $hel-grotesk;
+$font-family-base: $hel-grotesk;
+
+$font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+  "Helvetica Neue", Arial, sans-serif !default;
+$font-family-monospace: Menlo, Monaco, Consolas, "Liberation Mono",
+  "Courier New", monospace !default;
+$font-family-base: $font-family-sans-serif !default;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,5 +1,8 @@
+@import "fonts";
+
 * {
   padding: 0;
   margin: 0;
   box-sizing: border-box;
+  font-family: $font-family-base;
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,0 +1,1 @@
+@import "hds-design-tokens/lib/all";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,15 @@
+import { GetStaticPropsContext } from "next";
+
+export type NavigationItem = {
+  id: string;
+  path: string;
+  target: string;
+  title: string;
+  url: string;
+};
+
+export type InferDataGetterResult<T> = T extends (
+  context: GetStaticPropsContext
+) => PromiseLike<infer U>
+  ? U
+  : T;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1690,7 +1690,7 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-chokidar@3.5.1:
+chokidar@3.5.1, "chokidar@>=3.0.0 <4.0.0":
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
   integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
@@ -5416,6 +5416,13 @@ sane@^4.0.3:
     micromatch "^3.1.4"
     minimist "^1.1.1"
     walker "~1.0.5"
+
+sass@^1.32.12:
+  version "1.32.12"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.32.12.tgz#a2a47ad0f1c168222db5206444a30c12457abb9f"
+  integrity sha512-zmXn03k3hN0KaiVTjohgkg98C3UowhL1/VSGdj4/VAAiMKGQOE80PFPxFP2Kyq0OUskPKcY5lImkhBKEHlypJA==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
 
 saxes@^5.0.1:
   version "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3041,6 +3041,11 @@ hds-core@1.0.0:
   resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-1.0.0.tgz#314751120b169391d91313c6bd60bc215386b883"
   integrity sha512-7lEb8exIJ1uqczlrL3Ubr70B4L+90gTbiMj3mMyP1x5zafUBLK98LLT7N7+p5m+2JU6L7yfqBV2JkmCA5C+vAw==
 
+hds-design-tokens@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hds-design-tokens/-/hds-design-tokens-1.0.0.tgz#eb11b124838d6945bc4e7bfa46e6e120f3f7267a"
+  integrity sha512-03XUA6N9VRTnr1eaDnjkDRybMyOIAMzp6e7kCcaf0unAZIKO2LT0uR6gEA+JfCTakl8TfvUjqa4ZI7KRBd/q6g==
+
 hds-react@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-1.0.0.tgz#464dc2a9471d629729635e18173a7e4f5f6671bf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@alloc/types@^1.2.1":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@alloc/types/-/types-1.3.0.tgz#904245b8d3260a4b7d8a801c12501968f64fac08"
+  integrity sha512-mH7LiFiq9g6rX2tvt1LtwsclfG5hnsmtIfkZiauAGrm1AwXhoRS0sF2WrN9JGN7eV5vFXqNaB0eXZ3IvMsVi9g==
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -266,6 +271,13 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@7.11.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
@@ -273,7 +285,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.6.2", "@babel/runtime@^7.9.2":
   version "7.14.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
@@ -555,6 +567,11 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@juggle/resize-observer@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.2.0.tgz#5e0b448d27fe3091bae6216456512c5904d05661"
+  integrity sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg==
+
 "@next/env@10.2.0":
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-10.2.0.tgz#154dbce2efa3ad067ebd20b7d0aa9aed775e7c97"
@@ -619,6 +636,145 @@
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
+
+"@popperjs/core@2.5.3":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
+  integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
+
+"@reach/observe-rect@^1.1.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.2.0.tgz#d7a6013b8aafcc64c778a0ccb83355a11204d3b2"
+  integrity sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==
+
+"@react-aria/interactions@^3.2.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/interactions/-/interactions-3.4.0.tgz#0243947c962811314852399ebc0d9f663eb3b762"
+  integrity sha512-BCt0bP+XimcytkAVMQrpRfU/zlOFG1g6i6XmRnatsqq2Xc1ipQHr/MumE2cu8teXJZw2Q3e27VphCDNhCUkpnQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/utils" "^3.8.0"
+    "@react-types/shared" "^3.6.0"
+
+"@react-aria/ssr@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.0.2.tgz#f96a41a7314a60324b6de871cb872039b63be5c0"
+  integrity sha512-+M0wrUlc2eTuMiwTfd0iFZJGu2hvMeYBLE8gRdbPJCDjLhrNWOQLKR/y6ntxQ9u8zjrNl/YPOdRtcqkA2EBnAQ==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-aria/utils@^3.2.0", "@react-aria/utils@^3.8.0":
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.8.0.tgz#57bdc7cc967773c7f55b29847b187ec45031a620"
+  integrity sha512-VsFSeym4dB+A6t6Kl0MNSI9jYDijoLfy80z06AeGbv01xHGes86z5smvTGt3iW7u1vyYrwf+0h2WiCsF0Lw19g==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/ssr" "^3.0.2"
+    "@react-stately/utils" "^3.2.1"
+    "@react-types/shared" "^3.6.0"
+    clsx "^1.1.1"
+
+"@react-aria/visually-hidden@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@react-aria/visually-hidden/-/visually-hidden-3.2.0.tgz#740730368c8572de397c9d82ff5700fd7e034907"
+  integrity sha512-eqLfU4ISWyRb8UM1YFRnxXdjNpjQNixj0sHT8usWJNuQrZt0ebDdu/Kv2Ir3VUYr+GldoeKGYMDFHKwFLll1Hg==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@react-aria/interactions" "^3.2.0"
+    "@react-aria/utils" "^3.2.0"
+    clsx "^1.1.1"
+
+"@react-spring/animated@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/animated/-/animated-9.0.0-rc.3.tgz#e792cb76aacecfc78db2be6020ac11ce96503eb5"
+  integrity sha512-dAvgtKhkYpzzr+EkmZ4ZuJ5CujxCW0LaT109DvO/2MQNk3EWIxcgl+ik4tSulSbgau1GN8RlkRKyDp0wISdQ3Q==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/shared" "9.0.0-rc.3"
+    react-layout-effect "^1.0.1"
+
+"@react-spring/core@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/core/-/core-9.0.0-rc.3.tgz#c8e697573936c525bd0f6ca0c0869f75c86e8a83"
+  integrity sha512-3OzsVFxpfMJNkkQj8TwAH3NhUAX76AXu6WkslQF4EgBeEoG5eY3m+VvM9RsAsGWDuBKpscZ/wBpFt5Ih6KdGHA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/animated" "9.0.0-rc.3"
+    "@react-spring/shared" "9.0.0-rc.3"
+    react-layout-effect "^1.0.1"
+    use-memo-one "^1.1.0"
+
+"@react-spring/konva@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/konva/-/konva-9.0.0-rc.3.tgz#7bad631eb59f141001d668267314ca40546ecf97"
+  integrity sha512-uampLRgrHIqA3ilnheePUVEUE+fdeipXORI4XZJFsORP01CUJeJCxBwMagaxvsHJAtuNErMI/IebE1T2W8i5qA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/animated" "9.0.0-rc.3"
+    "@react-spring/core" "9.0.0-rc.3"
+    "@react-spring/shared" "9.0.0-rc.3"
+
+"@react-spring/native@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/native/-/native-9.0.0-rc.3.tgz#863b8278ea6064385c4fffaaed40316e4a2acaa8"
+  integrity sha512-7JSixJLfzg8V0IrgyGS3gGr2v8CGh4Kym15Htp3CJq74GFBJMyaQS0KaMjieXnw5alTpQoeGBESfA3v5dPlPYg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/animated" "9.0.0-rc.3"
+    "@react-spring/core" "9.0.0-rc.3"
+    "@react-spring/shared" "9.0.0-rc.3"
+
+"@react-spring/shared@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/shared/-/shared-9.0.0-rc.3.tgz#3f4c9d90accc20fef51a283a7806d78390b84161"
+  integrity sha512-dd50TxwwMWd+dSB0InjndUN9w17cbnMCPy+0sag6zRxxKIo7eOyWSliOtLKxvufgmdC8Prm4M3GT5dmB1yxKEQ==
+  dependencies:
+    "@alloc/types" "^1.2.1"
+    "@babel/runtime" "^7.3.1"
+    fluids "^0.1.6"
+    tslib "^1.11.1"
+
+"@react-spring/three@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/three/-/three-9.0.0-rc.3.tgz#bbfa7863c96ed8fa200cbff69222763c00977eef"
+  integrity sha512-H55T+Dnck+hsJ8WgE+tb89ngX1E1lDOpMBG4mGzNLGok6XgGqN0VBsHRN3QDl+aPfmJI1BPFPR6b6WbhwqRNbw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/animated" "9.0.0-rc.3"
+    "@react-spring/core" "9.0.0-rc.3"
+    "@react-spring/shared" "9.0.0-rc.3"
+
+"@react-spring/web@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/web/-/web-9.0.0-rc.3.tgz#da977382f91d9af4c400e4aa7dc37d3db07b87e0"
+  integrity sha512-rEvipblmihiz8+Eo01zDp5dqWn6XfYk8q2rlN9c18YIOL4o6nuY/VplDoocUMHYfH4liurpO4o1QudKOO1nAiQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/animated" "9.0.0-rc.3"
+    "@react-spring/core" "9.0.0-rc.3"
+    "@react-spring/shared" "9.0.0-rc.3"
+
+"@react-spring/zdog@9.0.0-rc.3":
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@react-spring/zdog/-/zdog-9.0.0-rc.3.tgz#00f611042b3761b984d0ca2c98da7dddcc11f081"
+  integrity sha512-fl2JI098sfOJ+BaS9xCrnz8NSimL8yPrVwO0lHSpXLn/q3o3MYmRAeJnZQv8yDtT6isTHua6Tfb9vWuZWEXSmA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/animated" "9.0.0-rc.3"
+    "@react-spring/core" "9.0.0-rc.3"
+    "@react-spring/shared" "9.0.0-rc.3"
+
+"@react-stately/utils@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.2.1.tgz#1e85861e6963230f80610bd9d1f5f0d33a481273"
+  integrity sha512-H79CYKPiQZrO1/dMSwjRJxsRlYg7y8PbTwnZOQ1h3DI5W6tD8CCLSlU1A5/Fp1GfcGNnK8gHqsJ9oJSRAwFS1g==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+
+"@react-types/shared@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.6.0.tgz#e3f32bdef168de9245648e9f0357930b13795bc2"
+  integrity sha512-oa8m+GP881IUQmi+L0UoM5aC5t/6L6QIEA2I1FUMgwMeJn24qPAcEqYrTWeJzX2S+gAfa5r9qbzcVEgpQorEUw==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -1591,6 +1747,11 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+clsx@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -1654,6 +1815,11 @@ component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+compute-scroll-into-view@^1.0.14:
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz#6a88f18acd9d42e9cf4baa6bec7e0522607ab7ab"
+  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -1846,6 +2012,16 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@2.16.1:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
+debounce@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
+
 debug@2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2001,6 +2177,16 @@ domexception@^2.0.1:
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+downshift@6.0.6:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.0.6.tgz#82aee8e2e260d7ad99df8a0969bd002dd523abe8"
+  integrity sha512-tmLab3cXCn6PtZYl9V8r/nB2m+7/nCNrwo0B3kTHo/2lRBHr+1en1VNOQt2wIt0ajanAnxquZ00WPCyxe6cNFQ==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    compute-scroll-into-view "^1.0.14"
+    prop-types "^15.7.2"
+    react-is "^16.13.1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -2584,6 +2770,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
+fluids@^0.1.6:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/fluids/-/fluids-0.1.10.tgz#0517e7a53dbce1db011dddec301b75178518ba0e"
+  integrity sha512-66FLmUJOrkvEHIsRVeM+88MG0bjd2TOBuR0BkM0hzyCb68W9drzqeX/AHDNp3ouZALQN7JvBvmKdVhHI+PZsdg==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2844,6 +3035,32 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+hds-core@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hds-core/-/hds-core-1.0.0.tgz#314751120b169391d91313c6bd60bc215386b883"
+  integrity sha512-7lEb8exIJ1uqczlrL3Ubr70B4L+90gTbiMj3mMyP1x5zafUBLK98LLT7N7+p5m+2JU6L7yfqBV2JkmCA5C+vAw==
+
+hds-react@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/hds-react/-/hds-react-1.0.0.tgz#464dc2a9471d629729635e18173a7e4f5f6671bf"
+  integrity sha512-Ckc0TWUJJIE7ezOVFyDyZ/Gszn+LPQi7zjEeAaFOjs7zjx4I+vDMV9W+k8r6/MWAOpf2nCq3YOMqKcRqDaxv+w==
+  dependencies:
+    "@babel/runtime" "7.11.2"
+    "@juggle/resize-observer" "3.2.0"
+    "@popperjs/core" "2.5.3"
+    "@react-aria/visually-hidden" "3.2.0"
+    date-fns "2.16.1"
+    downshift "6.0.6"
+    hds-core "1.0.0"
+    lodash.isequal "4.5.0"
+    lodash.isfunction "3.0.9"
+    lodash.uniqueid "4.0.1"
+    react-merge-refs "1.1.0"
+    react-popper "2.2.3"
+    react-spring "9.0.0-rc.3"
+    react-use-measure "2.0.1"
+    react-virtual "2.2.7"
 
 he@1.2.0:
   version "1.2.0"
@@ -3921,6 +4138,16 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.isequal@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.isfunction@3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
+  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -3931,12 +4158,17 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
+lodash.uniqueid@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz#3268f26a7c88e4f4b1758d679271814e31fa5b26"
+  integrity sha1-MmjyanyI5PSxdY1nknGBTjH6WyY=
+
 lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -4828,7 +5060,12 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-is@16.13.1, react-is@^16.8.1:
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-is@16.13.1, react-is@^16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -4838,10 +5075,56 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-layout-effect@^1.0.1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/react-layout-effect/-/react-layout-effect-1.0.5.tgz#0dc4e24452aee5de66c93c166f0ec512dfb1be80"
+  integrity sha512-zdRXHuch+OBHU6bvjTelOGUCM+UDr/iCY+c0wXLEAc+G4/FlcJruD/hUOzlKH5XgO90Y/BUJPNhI/g9kl+VAsA==
+
+react-merge-refs@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
+  integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
+
+react-popper@2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
+  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+  dependencies:
+    react-fast-compare "^3.0.1"
+    warning "^4.0.2"
+
 react-refresh@0.8.3:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
+
+react-spring@9.0.0-rc.3:
+  version "9.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-9.0.0-rc.3.tgz#0ad7b1e803f4385b7cbb44fff6d26f5be78884d6"
+  integrity sha512-VX5Gi6svgRzjGvJ7qVRQBhFN+O2IuPvkSWepIg838LNIMqlc42xdIYtoGJYSqYjNO3IocSfkHlh49WVw6hHMUg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@react-spring/core" "9.0.0-rc.3"
+    "@react-spring/konva" "9.0.0-rc.3"
+    "@react-spring/native" "9.0.0-rc.3"
+    "@react-spring/three" "9.0.0-rc.3"
+    "@react-spring/web" "9.0.0-rc.3"
+    "@react-spring/zdog" "9.0.0-rc.3"
+
+react-use-measure@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"
+  integrity sha512-lFfHiqcXbJ2/6aUkZwt8g5YYM7EGqNVxJhMqMPqv1BVXRKp8D7jYLlmma0SvhRY4WYxxkZpCdbJvhDylb5gcEA==
+  dependencies:
+    debounce "^1.2.0"
+
+react-virtual@2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/react-virtual/-/react-virtual-2.2.7.tgz#01f46e8eb1bfd722edb9a6e01daaef438dd7111f"
+  integrity sha512-ggnuqRwYRuuvFdkpD1tOfC5G4nr5xlZUvvp3b/c9r2Nf14dBXZR49oewESyNQnqyO5JT+offgd4oqugLxxdVsQ==
+  dependencies:
+    "@reach/observe-rect" "^1.1.0"
+    ts-toolbelt "^6.4.2"
 
 react@17.0.2:
   version "17.0.2"
@@ -5780,6 +6063,11 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
+ts-toolbelt@^6.4.2:
+  version "6.15.5"
+  resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"
+  integrity sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==
+
 tsconfig-paths@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
@@ -5790,7 +6078,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1:
+tslib@^1.11.1, tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -5938,6 +6226,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-memo-one@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.2.tgz#0c8203a329f76e040047a35a1197defe342fab20"
+  integrity sha512-u2qFKtxLsia/r8qG0ZKkbytbztzRb317XCkT7yP8wxL0tZ/CzK2G+WWie5vWvpyeP7+YoPIwbJoIHJ4Ba4k0oQ==
+
 use-subscription@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
@@ -6047,6 +6340,13 @@ walker@^1.0.7, walker@~1.0.5:
   integrity sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
   dependencies:
     makeerror "1.0.x"
+
+warning@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
+  integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==
+  dependencies:
+    loose-envify "^1.0.0"
 
 watchpack@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Adds top navigation to the application.

After this PR the application's landing page will render with a top navigation.

Some configurations were done to enable the navigation:
- HDS was added
- Helsinki Grotesk was added
- Layout logic was added
- Sass was added
- Meta data was added

In order to avoid implementing a too naive menu, I added mock data fetching logic for menu items.

This is sort of a problematic case with NextJS as currently there is no global, or app wide data fetching. See here: https://github.com/vercel/next.js/discussions/10949

Instead "global" data must be fetched view-by-view. This has the downside of creating duplicate code. I've implemented an initial approach for facilitating the fetching of menu data on each page.