### PR TITLE
LIIKUNTA-58 | Add popular now section

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -1,0 +1,99 @@
+import React, { useRef } from "react";
+import Link from "next/link";
+import { IconArrowRight } from "hds-react";
+
+import { Item } from "../../types";
+import Text from "../text/Text";
+import Keyword from "../keyword/Keyword";
+import styles from "./card.module.scss";
+
+function Card({ id, title, infoLines, keywords, pre, href, image }: Item) {
+  const linkRef = useRef(null);
+  const downRef = useRef<Date>(null);
+
+  const handleWrapperMouseDown = (e: React.MouseEvent<HTMLElement>) => {
+    downRef.current = new Date();
+  };
+
+  const handleWrapperMouseUp = (e: React.MouseEvent<HTMLElement>) => {
+    const link = linkRef.current;
+    const up = new Date();
+
+    // Invoke a click on link if
+    // 1. The event did not bubble from the link itself
+    // 2. The user is not attempting to select text
+    if (link !== e.target && up.getTime() - downRef.current.getTime() < 200) {
+      link.click();
+    }
+  };
+
+  return (
+    // These listeners allow us to provide a better UX for mouse while not
+    // hampering the UX for keybord or screen reader users.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    <article
+      onMouseDown={handleWrapperMouseDown}
+      onMouseUp={handleWrapperMouseUp}
+      className={styles.card}
+    >
+      <div className={styles.text}>
+        <Text as="h3" variant="body-l" className={styles.title}>
+          <Link href={href}>
+            {/* <Link /> applies the href prop to <a> */}
+            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+            <a
+              ref={linkRef}
+              className={styles.mainLink}
+              aria-describedby={`cta:${id}`}
+            >
+              {title}
+            </a>
+          </Link>
+        </Text>
+        <Text variant="body-l" className={styles.pre}>
+          {pre}
+        </Text>
+        <div className={styles.infoLines}>
+          {infoLines.map((infoLine) => (
+            <Text key={infoLine} variant="body" className={styles.infoLine}>
+              {infoLine}
+            </Text>
+          ))}
+        </div>
+      </div>
+      {/* This is a visual only guide that tells visual users that this card */}
+      {/* is clickable. It has a label so that visual screen reader users */}
+      {/* can interact with the element. */}
+      <span
+        className={styles.cta}
+        aria-hidden="true"
+        aria-label="Siirry sisältöön"
+        id={`cta:${id}`}
+      >
+        <IconArrowRight />
+      </span>
+      <ul className={styles.keywords}>
+        {keywords.map((keyword) => {
+          const label = keyword.label;
+
+          return (
+            <li key={label} className={styles.keyword}>
+              <Keyword
+                keyword={label}
+                onClick={() => {
+                  keyword.onClick();
+                }}
+                color={keyword.isHighlighted ? "tramLight20" : undefined}
+              />
+            </li>
+          );
+        })}
+      </ul>
+      <div className={styles.image}>
+        <img src={image} alt="" />
+      </div>
+    </article>
+  );
+}
+
+export default Card;

--- a/src/components/card/card.module.scss
+++ b/src/components/card/card.module.scss
@@ -19,6 +19,7 @@
   text-decoration: none;
 
   background-color: var(--color-white);
+  cursor: pointer;
 
   @include breakpoints.respond-above(m) {
     grid-template-columns: none;

--- a/src/components/card/card.module.scss
+++ b/src/components/card/card.module.scss
@@ -1,0 +1,199 @@
+@use "breakpoints";
+@import "variables";
+
+.card {
+  --height-image: 8rem;
+  --height-image-desktop: 14.5rem;
+  --width-image: 6.375rem;
+
+  display: grid;
+  grid-template-columns: var(--width-image) 1fr auto;
+  grid-template-rows: 1fr auto;
+  grid-template-areas:
+    "bg keywords cta"
+    "bg text cta";
+  height: 100%;
+  width: 100%;
+
+  color: var(--color-black);
+  text-decoration: none;
+
+  background-color: var(--color-white);
+
+  @include breakpoints.respond-above(m) {
+    grid-template-columns: none;
+    grid-template-rows: auto auto 1fr;
+    grid-template-areas:
+      "bg"
+      "text"
+      "cta";
+    margin-bottom: 0;
+  }
+
+  // Focus styles
+  &:focus-within {
+    outline: 2px solid $color-black;
+  }
+  .mainLink:focus {
+    text-decoration: underline;
+  }
+  &:focus-within .mainLink:focus {
+    text-decoration: none;
+    outline: none;
+  }
+  & .text:focus-within ~ .cta {
+    outline: 2px solid $color-black;
+  }
+
+  // Visual order
+  @include breakpoints.respond-above(m) {
+    .image {
+      order: 0;
+    }
+    .text {
+      order: 1;
+    }
+  }
+
+  // Grid positions
+  .image {
+    grid-area: bg;
+  }
+
+  .keywords {
+    grid-area: keywords;
+  }
+
+  .text {
+    grid-area: text;
+  }
+
+  .cta {
+    grid-area: cta;
+  }
+
+  @include breakpoints.respond-above(m) {
+    .image,
+    .keywords {
+      grid-area: bg;
+    }
+  }
+
+  // Component styles
+  .image {
+    min-height: var(--height-image);
+    display: flex;
+    box-sizing: border-box;
+    overflow: hidden;
+
+    text-decoration: none;
+
+    @include breakpoints.respond-above(m) {
+      min-height: var(--height-image-desktop);
+      max-height: var(--height-image-desktop);
+    }
+
+    img {
+      display: block;
+      object-fit: cover;
+      width: 100%;
+    }
+  }
+
+  .keywords {
+    margin: 0;
+    margin-bottom: inherit;
+    padding: $spacing-xs;
+    padding-bottom: 0;
+    display: flex;
+    align-items: flex-end;
+    position: relative;
+
+    @include breakpoints.respond-above(m) {
+      padding: $spacing-s;
+    }
+
+    .keyword {
+      list-style-type: none;
+    }
+  }
+
+  .text {
+    padding: $spacing-s;
+    // Use a grid so that spacing can be applied with gap
+    display: grid;
+    grid-template-columns: auto;
+    grid-gap: $spacing-xs;
+
+    & > * {
+      margin-bottom: 0;
+    }
+
+    // Show pre before title, but retain title as first in the DOM order
+    .pre {
+      order: 1;
+    }
+    & > * {
+      order: 2;
+    }
+
+    .pre {
+      font-weight: 500;
+    }
+
+    .mainLink {
+      color: $color-black;
+      text-decoration: none;
+    }
+
+    .aws {
+      color: $color-black;
+      text-decoration: none;
+    }
+
+    .infoLines {
+      display: inherit;
+      grid-template-columns: inherit;
+      grid-gap: inherit;
+
+      & > *:not(:last-child) {
+        display: none;
+
+        @include breakpoints.respond-above(m) {
+          display: initial;
+        }
+      }
+    }
+  }
+
+  .cta {
+    align-self: center;
+    display: flex;
+    height: 2.5rem;
+    width: 2.5rem;
+    padding: 0;
+    margin: 0 $spacing-xs 0 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    color: var(--color-black);
+
+    background-color: var(--color-copper-light);
+    border-color: var(--color-copper-light);
+
+    @include breakpoints.respond-above(m) {
+      margin: 0 0 $spacing-s $spacing-s;
+      align-self: flex-end;
+    }
+
+    svg {
+      height: 1.5rem;
+      width: 1.5rem;
+    }
+
+    &:focus {
+      outline: 2px solid var(--color-black);
+    }
+  }
+}

--- a/src/components/keyword/Keyword.tsx
+++ b/src/components/keyword/Keyword.tsx
@@ -1,0 +1,40 @@
+import classNames from "classnames";
+import React from "react";
+
+import styles from "./keyword.module.scss";
+
+type Props = {
+  blackOnMobile?: boolean;
+  color?: "engelLight50" | "tramLight20";
+  hideOnMobile?: boolean;
+  keyword: string;
+  onClick: () => void;
+};
+
+const Keyword = ({
+  blackOnMobile,
+  color,
+  hideOnMobile,
+  keyword,
+  onClick,
+}: Props) => {
+  const handleClick = (ev: React.MouseEvent) => {
+    ev.preventDefault();
+    onClick();
+  };
+
+  return (
+    <button
+      className={classNames(styles.keyword, color && styles[color], {
+        [styles.blackOnMobile]: blackOnMobile,
+        [styles.hideOnMobile]: hideOnMobile,
+      })}
+      onClick={handleClick}
+      type="button"
+    >
+      {keyword}
+    </button>
+  );
+};
+
+export default Keyword;

--- a/src/components/keyword/keyword.module.scss
+++ b/src/components/keyword/keyword.module.scss
@@ -1,0 +1,45 @@
+@use 'breakpoints';
+
+.keyword {
+  height: auto;
+  min-height: 1.5rem;
+  margin: 0.1875rem 0.375rem 0.1875rem 0;
+  display: inline-flex;
+  padding: 0.125rem 0.5rem;
+  align-items: center;
+
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-black);
+
+  background-color: var(--color-summer-medium-light);
+  border: none;
+
+  &.blackOnMobile {
+    background-color: var(--color-black-80);
+    color: var(--color-white);
+
+    @include breakpoints.respond-above(m) {
+      background-color: var(--color-summer-medium-light);
+      color: var(--color-black);
+    }
+  }
+
+  &.hideOnMobile {
+    display: none;
+
+    @include breakpoints.respond-above(m) {
+      display: initial;
+    }
+  }
+
+  &.engelLight50 {
+    background-color: var(--color-engel-medium-light);
+    color: var(--color-black);
+  }
+
+  &.tramLight20 {
+    background-color: var(--color-tram-light);
+    color: var(--color-black);
+  }
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -18,7 +18,9 @@ function AppLayout({
         navigationItems={navigationItems}
         languages={languages}
       />
-      <main id={MAIN_CONTENT_ID}>{children}</main>
+      <main id={MAIN_CONTENT_ID} className={styles.main}>
+        {children}
+      </main>
       <Footer />
     </div>
   );

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -2,8 +2,11 @@
 @import "variables";
 
 .Layout {
+  // Custom non-HDS compliant max width for content. Breaks alignment with
+  // for instance Navigation.
+  --liikunta-width: 100rem; // 1600px
   --spacing: #{$spacing-layout-2-xs};
-  --content-width: calc(var(--breakpoint-xl) - 2 * #{$spacing-layout-xs});
+  --content-width: calc(var(--liikunta-width) - 2 * #{$spacing-layout-xs});
 
   display: grid;
   // Set a three column layout where the middle column is the content column
@@ -22,5 +25,16 @@
 
   @include breakpoints.respond-above(m) {
     --spacing: #{$spacing-layout-xs};
+  }
+
+  .main {
+    grid-column: 1 / -1;
+
+    display: inherit;
+    grid-template-columns: inherit;
+
+    & > * {
+      grid-column: 2;
+    }
   }
 }

--- a/src/components/list/List.tsx
+++ b/src/components/list/List.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import { Item } from "../../types";
+import styles from "./list.module.scss";
+
+type Props = {
+  items: Item[];
+  component: React.ComponentType<Item>;
+};
+
+function List({ items, component: Component }: Props) {
+  return (
+    <ul className={styles.list}>
+      {items.map((item) => (
+        <li key={item.id} className={styles.item}>
+          <Component key={item.id} {...item} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default List;

--- a/src/components/list/list.module.scss
+++ b/src/components/list/list.module.scss
@@ -1,0 +1,23 @@
+@use "breakpoints";
+@import "variables";
+
+.list {
+  --base-list-item-width: 22rem; // 352px
+
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fit,
+    minmax(var(--base-list-item-width), 1fr)
+  );
+  grid-gap: $spacing-xs;
+
+  @include breakpoints.respond-above(m) {
+    grid-gap: $spacing-layout-m;
+  }
+
+  .item {
+    list-style-type: none;
+  }
+}

--- a/src/components/section/Section.tsx
+++ b/src/components/section/Section.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import Text from "../text/Text";
+import styles from "./section.module.scss";
+
+type Props = {
+  title: string;
+  children: React.ReactNode;
+};
+
+function Section({ title, children }: Props) {
+  return (
+    <section className={styles.section}>
+      <Text variant="h2" className={styles.title}>
+        {title}
+      </Text>
+      {children}
+    </section>
+  );
+}
+
+export default Section;

--- a/src/components/section/section.module.scss
+++ b/src/components/section/section.module.scss
@@ -1,0 +1,19 @@
+@import "variables";
+
+.section {
+  grid-column: 1 / -1 !important;
+  display: inherit;
+  grid-template-columns: inherit;
+  grid-template-rows: inherit;
+  padding: $spacing-layout-m 0;
+
+  background: $color-black-5;
+
+  & > * {
+    grid-column: 2;
+  }
+
+  .title {
+    margin-bottom: $spacing-layout-m;
+  }
+}

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -1,0 +1,42 @@
+import React, { ReactNode, HTMLAttributes } from "react";
+
+import styles from "./text.module.scss";
+
+type TextVariant = "h1" | "h2" | "h3" | "h4" | "body" | "body-l";
+
+type Props = {
+  as?: string | React.ComponentType<HTMLAttributes<HTMLElement>>;
+  variant: TextVariant;
+  children: ReactNode;
+  className?: string;
+};
+
+function getElement(variant: TextVariant) {
+  switch (variant) {
+    case "h1":
+      return "h1";
+    case "h2":
+      return "h2";
+    case "h3":
+      return "h3";
+    case "h4":
+      return "h4";
+    case "body":
+    case "body-l":
+    default:
+      return "p";
+  }
+}
+
+function Text({ as, variant = "body", children, className, ...rest }: Props) {
+  return React.createElement(
+    as || getElement(variant),
+    {
+      className: [styles.text, styles[variant], className].join(" "),
+      ...rest,
+    },
+    children
+  );
+}
+
+export default Text;

--- a/src/components/text/text.module.scss
+++ b/src/components/text/text.module.scss
@@ -1,0 +1,48 @@
+@use "breakpoints";
+@import "variables";
+
+.text {
+  color: $color-black-90;
+}
+.text:last-child {
+  margin-bottom: 0;
+}
+
+.h1 {
+  margin: 0 0 $spacing-s 0;
+
+  font-size: $fontsize-heading-l;
+  line-height: $lineheight-l;
+
+  @include breakpoints.respond-above(s) {
+    font-size: $fontsize-heading-xl;
+  }
+}
+
+.h2 {
+  margin: 0 0 $spacing-s 0;
+
+  font-size: $fontsize-heading-l;
+}
+
+.h3 {
+  margin: 0 0 $spacing-s 0;
+
+  font-size: $fontsize-heading-m;
+}
+
+.h4 {
+  margin: 0 0 $spacing-s 0;
+
+  font-size: $fontsize-heading-s;
+}
+
+.body-l {
+  margin: 0 0 $spacing-m 0;
+
+  font-size: $fontsize-body-l;
+}
+
+.body {
+  font-size: $fontsize-body-m;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,36 @@
 import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
+import { useRouter } from "next/dist/client/router";
 
 import Page from "../components/page/Page";
 import getPageData from "../components/page/getPageData";
+import Section from "../components/section/Section";
+import List from "../components/list/List";
+import Card from "../components/card/Card";
+import { Item } from "../types";
 
 export default function Home({
   page,
+  recommendations,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
+  const router = useRouter();
+
+  const recommendationItems: Item[] = recommendations.map((recommendation) => ({
+    ...recommendation,
+    keywords: recommendation.keywords.map((keyword) => ({
+      label: keyword,
+      onClick: () => {
+        router.push(`keywords/${encodeURIComponent(keyword)}`);
+      },
+      isHighlighted: keyword === "Maksuton",
+    })),
+  }));
+
   return (
     <Page title="Liikunta-Helsinki" description="Liikunta-helsinki" {...page}>
       <h1>Liikunta-Helsinki</h1>
+      <Section title="Suosittua juuri nyt">
+        <List component={Card} items={recommendationItems} />
+      </Section>
     </Page>
   );
 }
@@ -17,6 +39,54 @@ export async function getStaticProps(context: GetStaticPropsContext) {
   return {
     props: {
       page: await getPageData(context),
+      recommendations: mockRecommendations,
     },
   };
 }
+
+const mockRecommendations = [
+  {
+    id: "1",
+    keywords: ["Tänään"],
+    pre: "12.5.2021, klo 19.00",
+    title: "Karanteeniteatteri: Naurua kolmannella (stream)",
+    infoLines: [
+      "Tiivistämö, Sörnäisten rantatie 22 / Kaasutehtaankatu 1, Helsinki",
+      "12€ + palvelumaksu",
+    ],
+    href: `/event/1`,
+    image: "https://api.hel.fi/linkedevents/media/images/naurua3.jpg",
+  },
+  {
+    id: "2",
+    keywords: ["Tällä viikolla", "Maksuton"],
+    pre: "11 – 25.5.2021",
+    title: "Bachin Collegium Musicum",
+    infoLines: ["Maunula-talo, Metsäpurontie 4, Helsinki", "Maksuton"],
+    href: `/event/2`,
+    image:
+      "https://api.hel.fi/linkedevents/media/images/t%C3%A4m%C3%A4np%C3%A4iv%C3%A4iset_runot_1200x800.jpg",
+  },
+  {
+    id: "3",
+    keywords: ["Tällä viikolla"],
+    pre: "15.5.2021, klo 21.00 – 23.00",
+    title: "Tiivistämö Comedy Stream: All Female Panel",
+    infoLines: [
+      "Tiivistämö, Sörnäisten rantatie 22 / Kaasutehtaankatu 1, Helsinki",
+      "13,5€",
+    ],
+    href: `/event/3`,
+    image: "https://api.hel.fi/linkedevents/media/images/allfemalepanel05.jpg",
+  },
+  {
+    id: "4",
+    keywords: [],
+    pre: "16.5.2021, klo 18.00 – 20.00",
+    title: "Exit – Kautta aikojen livestream",
+    infoLines: ["Internet", "18€"],
+    href: `/event/4`,
+    image:
+      "https://api.hel.fi/linkedevents/media/images/EXIT_FBT_160521_1920x1080.jpg",
+  },
+];

--- a/src/tests/index.test.tsx
+++ b/src/tests/index.test.tsx
@@ -66,6 +66,20 @@ describe("App", () => {
             },
             languages,
           }}
+          recommendations={[
+            {
+              id: "1",
+              keywords: ["Tänään"],
+              pre: "12.5.2021, klo 19.00",
+              title: "Karanteeniteatteri: Naurua kolmannella (stream)",
+              infoLines: [
+                "Tiivistämö, Sörnäisten rantatie 22 / Kaasutehtaankatu 1, Helsinki",
+                "12€ + palvelumaksu",
+              ],
+              href: `/event/1`,
+              image: "https://api.hel.fi/linkedevents/media/images/naurua3.jpg",
+            },
+          ]}
         />
       </RouterContext.Provider>
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,3 +21,19 @@ export type Language = {
   code: string;
   locale: string;
 };
+
+type Keyword = {
+  label: string;
+  isHighlighted?: boolean;
+  onClick: () => void;
+};
+
+export type Item = {
+  id: string;
+  title: string;
+  pre: string;
+  infoLines: string[];
+  keywords: Keyword[];
+  href: string;
+  image: string;
+};


### PR DESCRIPTION
Adds a mock "popular no" section.

Takes inspiration and copies code from Tapahtumat.

I used an approach with the cards where they are not wrapped in an interactive element such as a link to make them easier to use with screen readers. However, I implemented some special logic for mouse users which allows them to click anywhere on the card to fire the navigation routine.

I also implemented the "call to action" (the arrow button) in a way where it's not focusable and as such does not introduce extra focusable elements, but does still communicate it's presence to sighted screen reader users (niche uscases).

I adopted a MVVM pattern with the card for now. I'll develop the approach further while implementing collections.

I could not find recommendations from WP so I was not able to mimic the data model.