### PR TITLE
LIIKUNTA-54 | Add footer from HDS

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -1,0 +1,65 @@
+import { Footer as HDSFooter, LogoLanguage } from "hds-react";
+import React from "react";
+import { useRouter } from "next/dist/client/router";
+import NextLink from "next/link";
+
+import styles from "./footer.module.scss";
+import { NavigationItem } from "../../types";
+
+type LinkProps = {
+  href: string;
+  locale?: React.ComponentProps<typeof NextLink>["locale"];
+  lang?: string;
+  children?: React.ReactNode;
+};
+
+const Link = ({ href, children, locale, ...rest }: LinkProps) => {
+  return (
+    <NextLink href={href} locale={locale}>
+      <a {...rest}>{children}</a>
+    </NextLink>
+  );
+};
+
+type Props = {
+  navigationItems: NavigationItem[];
+};
+
+function Footer({ navigationItems }: Props) {
+  const { locale } = useRouter();
+  const logoLanguage: LogoLanguage = locale === "sv" ? "sv" : "fi";
+  return (
+    <HDSFooter
+      title="Liikunta"
+      className={styles.footer}
+      logoLanguage={logoLanguage}
+    >
+      <HDSFooter.Navigation>
+        {navigationItems.map((navigationItem) => (
+          <HDSFooter.Item
+            key={navigationItem.id}
+            as={Link}
+            label={navigationItem.title}
+            href={navigationItem.url}
+          />
+        ))}
+      </HDSFooter.Navigation>
+      <HDSFooter.Utilities backToTopLabel="Takaisin alkuun">
+        <HDSFooter.Item
+          className={styles.FooterUtilities}
+          href="#"
+          label="Anna palautetta"
+        />
+      </HDSFooter.Utilities>
+      <HDSFooter.Base
+        copyrightHolder="Copyright"
+        copyrightText="Kaikki oikeudet pidätetään"
+      >
+        <HDSFooter.Item href="#" label="Tietoa palvelusta" />
+        <HDSFooter.Item href="#" label="Saavutettavuusseloste" />
+      </HDSFooter.Base>
+    </HDSFooter>
+  );
+}
+
+export default Footer;

--- a/src/components/footer/footer.module.scss
+++ b/src/components/footer/footer.module.scss
@@ -1,0 +1,29 @@
+@use "breakpoints";
+@import "variables";
+
+.footer {
+  --footer-background: #{$color-engel-medium-light} !important;
+  grid-column: 1 / -1 !important;
+
+  // koros stuff
+  margin-top: -1rem;
+  > div > svg {
+    width: 100%;
+  }
+
+  // fix "back to top" button positioning being slightly off
+  @include breakpoints.respond-above(s) {
+    > div > div > div > button {
+      top: -3px;
+    }
+  }
+
+  // align utility links to right also now when there are no SoMe items
+  @include breakpoints.respond-above(m) {
+    > div > div:nth-child(2) {
+      display: grid;
+      justify-items: end;
+      justify-content: unset;
+    }
+  }
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -3,10 +3,9 @@ import React from "react";
 import Navigation from "../navigation/Navigation";
 import { LayoutComponentProps } from "./types";
 import styles from "./layout.module.scss";
+import Footer from "../footer/Footer";
 
 const MAIN_CONTENT_ID = "main-content";
-
-const Footer = () => <footer>Footer</footer>;
 
 function Layout({ children, languages, menuItems }: LayoutComponentProps) {
   return (
@@ -19,7 +18,7 @@ function Layout({ children, languages, menuItems }: LayoutComponentProps) {
       <main id={MAIN_CONTENT_ID} className={styles.main}>
         {children}
       </main>
-      <Footer />
+      <Footer navigationItems={menuItems} />
     </div>
   );
 }

--- a/src/components/section/section.module.scss
+++ b/src/components/section/section.module.scss
@@ -11,6 +11,11 @@
 
   background: $color-black-5;
 
+  &:last-child {
+    // even out footer koros margin
+    padding-bottom: $spacing-layout-m + 1rem;
+  }
+
   & > * {
     grid-column: 2;
     margin-bottom: 0;


### PR DESCRIPTION
Added HDS footer with a few tweaks:

* utility links are aligned to right side, normally they would go to left side when there are no SoMe items
* "back to top" button's slight vertical positioning error fixed

There is a known issue that the koros element inside the footer causes a warning about IDs not matching in server and client, but it shouldn't cause any real harm, and seems to be hard to fix, so it can be addressed later.

<img width="1663" alt="Screenshot 2021-05-19 at 8 54 12" src="https://user-images.githubusercontent.com/1314604/118763020-d4792a80-b87f-11eb-994d-f7928b2267c6.png">
