### PR TITLE
LIIKUNTA-29 | Fetch page data in a separate query

### DIFF
--- a/src/api/cmsApolloClient.ts
+++ b/src/api/cmsApolloClient.ts
@@ -12,6 +12,9 @@ function createCmsApolloClient() {
     uri: Config.cmsGraphqlEndpoint,
     cache: new InMemoryCache({
       typePolicies: {
+        RootQuery: {
+          queryType: true,
+        },
         MenuItems: {
           fields: {
             nodes: {

--- a/src/api/tmp/menuItems.ts
+++ b/src/api/tmp/menuItems.ts
@@ -11,7 +11,7 @@ const menuItems: (MenuItem & { __typename: string })[] = [
     url: "/haku",
   },
   {
-    __typename: "MenuItems",
+    __typename: "MenuItem",
     id: "3",
     order: 2,
     path: "/liikuntatunnit",
@@ -20,7 +20,7 @@ const menuItems: (MenuItem & { __typename: string })[] = [
     url: "/liikuntatunnit",
   },
   {
-    __typename: "MenuItems",
+    __typename: "MenuItem",
     id: "2",
     order: 1,
     path: "/liikuntapaikat",
@@ -29,7 +29,7 @@ const menuItems: (MenuItem & { __typename: string })[] = [
     url: "/liikuntapaikat",
   },
   {
-    __typename: "MenuItems",
+    __typename: "MenuItem",
     id: "4",
     order: 3,
     path: "/ryhmat",

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -13,3 +13,11 @@ export function sortMenuItems(menuItemsConnection: { nodes: MenuItem[] }) {
     nodes: sortedMenuItems,
   };
 }
+
+export function getQlLanguage(language: string) {
+  return {
+    fi: "FI",
+    sv: "SV",
+    en: "EN",
+  }[language];
+}

--- a/src/tests/index.test.tsx
+++ b/src/tests/index.test.tsx
@@ -25,7 +25,7 @@ const getMocks = () => [
       query: PAGE_QUERY,
     },
     response: {
-      languages: [
+      pageLanguages: [
         {
           id: "1",
           name: "English",
@@ -34,7 +34,7 @@ const getMocks = () => [
           locale: "en_US",
         },
       ],
-      menuItems: {
+      pageMenuItems: {
         nodes: [
           {
             id: "1",


### PR DESCRIPTION
In preparation for LIIKUNTA-29, simplify `pageQuery` logic and declare `RootQuery` as a query type in order to allow Apollo's cache to be built correctly.