### PR TITLE
LIIKUNTA-63 | Add suggestion to free text search

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -21,3 +21,10 @@ export function getQlLanguage(language: string) {
     en: "EN",
   }[language];
 }
+export function getUnifiedSearchLanguage(language: string) {
+  return {
+    fi: "FINNISH",
+    sv: "SWEDISH",
+    en: "ENGLISH",
+  }[language];
+}

--- a/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -12,6 +12,12 @@ import styles from "./searchPageSearchForm.module.scss";
 import searchApolloClient from "../../../api/searchApolloClient";
 import { getUnifiedSearchLanguage } from "../../../api/utils";
 
+function getURLSearchParamsFromAsPath(asPath: string): URLSearchParams {
+  const [, searchParams] = asPath.split("?");
+
+  return new URLSearchParams(searchParams);
+}
+
 const SUGGESTION_QUERY = gql`
   query SuggestionQuery($prefix: String, $language: UnifiedSearchLanguage!) {
     unifiedSearchCompletionSuggestions(
@@ -29,7 +35,7 @@ const SUGGESTION_QUERY = gql`
 function SearchPageSearchForm() {
   const router = useRouter();
   const [searchText, setSearchText] = useState<string>(
-    (router.query?.q as string) ?? ""
+    getURLSearchParamsFromAsPath(router.asPath).get("q") ?? ""
   );
   const [findSuggestions, { data }] = useLazyQuery(SUGGESTION_QUERY, {
     client: searchApolloClient,

--- a/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -10,10 +10,15 @@ import SuggestionInput, {
 } from "../../suggestionInput/SuggestionInput";
 import styles from "./searchPageSearchForm.module.scss";
 import searchApolloClient from "../../../api/searchApolloClient";
+import { getUnifiedSearchLanguage } from "../../../api/utils";
 
 const SUGGESTION_QUERY = gql`
-  query SuggestionQuery($prefix: String) {
-    unifiedSearchCompletionSuggestions(prefix: $prefix, index: "location") {
+  query SuggestionQuery($prefix: String, $language: UnifiedSearchLanguage!) {
+    unifiedSearchCompletionSuggestions(
+      prefix: $prefix
+      index: "location"
+      languages: [$language]
+    ) {
       suggestions {
         label
       }
@@ -47,6 +52,9 @@ function SearchPageSearchForm() {
     debouncedFindSuggestions.current({
       variables: {
         prefix: value,
+        language: getUnifiedSearchLanguage(
+          router.locale || router.defaultLocale
+        ),
       },
     });
   };

--- a/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -23,7 +23,9 @@ const SUGGESTION_QUERY = gql`
 
 function SearchPageSearchForm() {
   const router = useRouter();
-  const [searchText, setSearchText] = useState<string>("");
+  const [searchText, setSearchText] = useState<string>(
+    (router.query?.q as string) ?? ""
+  );
   const [findSuggestions, { data }] = useLazyQuery(SUGGESTION_QUERY, {
     client: searchApolloClient,
   });

--- a/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -1,6 +1,6 @@
 import { Button, IconSearch } from "hds-react";
 import React, { useState, useRef } from "react";
-import { useRouter } from "next/dist/client/router";
+import { useRouter } from "next/router";
 import { gql, useLazyQuery } from "@apollo/client";
 import debounce from "lodash/debounce";
 

--- a/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -1,4 +1,4 @@
-import { Button } from "hds-react";
+import { Button, IconSearch } from "hds-react";
 import React, { useState, useRef } from "react";
 import { useRouter } from "next/dist/client/router";
 import { gql, useLazyQuery } from "@apollo/client";
@@ -73,7 +73,9 @@ function SearchPageSearchForm() {
             label: suggestion.label,
           }))}
         />
-        <Button type="submit">Hae</Button>
+        <Button type="submit" iconLeft={<IconSearch />}>
+          Hae
+        </Button>
       </form>
     </div>
   );

--- a/src/components/search/searchPageSearchForm/searchPageSearchForm.module.scss
+++ b/src/components/search/searchPageSearchForm/searchPageSearchForm.module.scss
@@ -24,6 +24,6 @@
   grid-gap: $spacing-m;
 
   @include breakpoints.respond-above(s) {
-    grid-template-columns: 2fr 1fr;
+    grid-template-columns: 3fr 1fr;
   }
 }

--- a/src/components/search/searchPageSearchForm/searchPageSearchForm.module.scss
+++ b/src/components/search/searchPageSearchForm/searchPageSearchForm.module.scss
@@ -26,23 +26,4 @@
   @include breakpoints.respond-above(s) {
     grid-template-columns: 2fr 1fr;
   }
-
-  .inputWithIcon {
-    position: relative;
-
-    & > div > input {
-      border: none !important;
-      padding-left: calc((2 * #{$spacing-s}) + 1.5rem) !important;
-    }
-
-    & > div > svg {
-      position: absolute;
-      left: $spacing-layout-2-xs;
-      bottom: $spacing-layout-2-xs;
-
-      & * {
-        color: $color-black-90;
-      }
-    }
-  }
 }

--- a/src/components/suggestionInput/SuggestionInput.tsx
+++ b/src/components/suggestionInput/SuggestionInput.tsx
@@ -1,0 +1,98 @@
+import { useCombobox } from "downshift";
+import { TextInput, IconSearch, IconAngleDown } from "hds-react";
+
+import styles from "./suggestionInput.module.scss";
+
+export type Suggestion = {
+  id: string;
+  label: string;
+};
+
+type Props = {
+  id: string;
+  name: string;
+  placeholder?: string;
+  onChange?: (value: string) => void;
+  onSelectedItemChange?: (suggestion: Suggestion) => void;
+  value: string;
+  label: string;
+  suggestions: Suggestion[];
+};
+
+function DropdownCombobox({
+  label,
+  onChange,
+  onSelectedItemChange,
+  suggestions,
+  value,
+  ...rest
+}: Props) {
+  const {
+    isOpen,
+    // selectedItem,
+    getToggleButtonProps,
+    getLabelProps,
+    getMenuProps,
+    getInputProps,
+    getComboboxProps,
+    highlightedIndex,
+    getItemProps,
+  } = useCombobox({
+    items: suggestions,
+    itemToString: (item: Suggestion) => item.label,
+    inputValue: value,
+    onInputValueChange: ({ inputValue }) => {
+      if (onChange) {
+        onChange(inputValue);
+      }
+    },
+    onSelectedItemChange: ({ selectedItem }) => {
+      if (onSelectedItemChange) {
+        onSelectedItemChange(selectedItem);
+      }
+    },
+  });
+
+  return (
+    <div className={styles.suggestionControl}>
+      <div className={styles.suggestionControl}>
+        <label {...getLabelProps()}>{label}</label>
+        <div {...getComboboxProps()}>
+          <TextInput
+            {...getInputProps()}
+            className={styles.suggestionInput}
+            {...rest}
+          >
+            <IconSearch aria-hidden="true" />
+            <button
+              type="button"
+              {...getToggleButtonProps()}
+              aria-label="toggle menu"
+            >
+              <IconAngleDown aria-hidden="true" />
+            </button>
+          </TextInput>
+        </div>
+      </div>
+      <ul
+        {...getMenuProps()}
+        className={[styles.suggestions, isOpen ? styles.open : null]
+          .filter((item) => item)
+          .join(" ")}
+      >
+        {isOpen &&
+          suggestions.map((item, index) => (
+            <li
+              key={item.id}
+              className={highlightedIndex === index ? styles.selected : null}
+              {...getItemProps({ item, index })}
+            >
+              {item.label}
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+}
+
+export default DropdownCombobox;

--- a/src/components/suggestionInput/SuggestionInput.tsx
+++ b/src/components/suggestionInput/SuggestionInput.tsx
@@ -59,7 +59,18 @@ function DropdownCombobox({
         <label {...getLabelProps()}>{label}</label>
         <div {...getComboboxProps()}>
           <TextInput
-            {...getInputProps()}
+            {...getInputProps({
+              onKeyDown: (event) => {
+                // When the user presses the enter key while not highlighting
+                // any option.
+                if (event.key === "Enter" && highlightedIndex === -1) {
+                  // Prevent Downshift's default 'Enter' behavior.
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore
+                  event.nativeEvent.preventDownshiftDefault = true;
+                }
+              },
+            })}
             className={styles.suggestionInput}
             {...rest}
           >

--- a/src/components/suggestionInput/suggestionInput.module.scss
+++ b/src/components/suggestionInput/suggestionInput.module.scss
@@ -1,0 +1,81 @@
+@import "variables";
+
+.suggestionControl {
+  position: relative;
+
+  & > label {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  .suggestionInput {
+    position: relative;
+
+    & > div > input {
+      border-color: transparent;
+      padding-left: calc((2 * #{$spacing-s}) + 1rem) !important;
+    }
+
+    & > div > *:not(input) {
+      position: absolute;
+      bottom: $spacing-layout-2-xs;
+
+      &:nth-child(2) {
+        left: calc(#{$spacing-layout-2-xs} + 2px);
+      }
+
+      &:nth-child(3) {
+        right: $spacing-layout-2-xs;
+      }
+    }
+
+    & > div > svg {
+      & * {
+        color: $color-black-90;
+      }
+    }
+
+    & > div > button {
+      display: flex;
+
+      border: none;
+      background: none;
+    }
+  }
+}
+
+.suggestions {
+  &.open {
+    position: absolute;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    left: 2px;
+    right: 2px;
+    z-index: 100;
+
+    background: $color-white;
+    // border: 2px solid $color-black-90;
+    border-top: 1px solid $color-black-20;
+    transform: translateY(-2px);
+
+    & > li {
+      padding: $spacing-xs $spacing-s;
+      min-height: calc(#{$spacing-3-xl} - 4px);
+
+      font-size: $fontsize-body-l;
+      line-height: $lineheight-l;
+
+      &.selected {
+        color: $color-white;
+
+        background-color: $color-bus;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Now while the user types, the UI should offer suggestions for the user. The suggestions should be in the currently chosen language.

### Custom Dropdown implementation with Downshift

The Combobox in HDS doesn't support our usecase. The combobox is designed for selecting one option from many. Our usecase is a text field that allows the user to optionally choose from a curated option list. The technical detail that makes it impossible to use Combobox is that it doesn't allow us to control the value of the input, which is why we are not able to track the value of the input--and hence make searches with it.

I implemented a custom dropdown which uses the same tooling as HDS does for its dropdown implementation.

The implementation lends more from HDS than from the implementation in events.

### Debouncing

I added a very basic debouncing measure. This should limit the amount of times the UI reacts to suggestion request responses. In other words, if users write many letters in quick succession, only the search done after the final letter will get rendered in the UI. I'm not sure but the request themselves may also get debounced.

This isn't an entirely foolproof approach with Apollo, but it seemed to work with this usecase.