### PR TITLE
LIIKUNTA-64 | Fix FOUC with statically optimized pages

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import { ApolloProvider } from "@apollo/client";
 import type { AppProps } from "next/app";
+import { useEffect } from "react";
 
 import { useCmsApollo } from "../api/cmsApolloClient";
 import AppMeta from "../components/meta/AppMeta";
@@ -7,6 +8,22 @@ import "../styles/globals.scss";
 
 function MyApp({ Component, pageProps }: AppProps) {
   const cmsApolloClient = useCmsApollo(pageProps.initialApolloState);
+
+  // Unset hidden visibility that was applied to hide the first server render
+  // that does not include styles from HDS. HDS applies styling by injecting
+  // style tags into the head. This requires the existence of a document object.
+  // The document object does not exist during server side renders.
+  // TODO: Remove this hackfix to ensure that pre-rendered pages'
+  //       SEO performance is not impacted.
+  useEffect(() => {
+    setTimeout(() => {
+      const body = document?.body;
+
+      if (body) {
+        body.style.visibility = "unset";
+      }
+    }, 10);
+  }, []);
 
   return (
     <ApolloProvider client={cmsApolloClient}>

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,26 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+class LiikuntDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head />
+        {/* HDS embeds styles into the head of the document. Hence for HDS */}
+        {/* styles to be applied, the document object must be available. */}
+        {/* The document object is not available during server side renders. */}
+        {/* Circumventing this issue is too difficult and means too many */}
+        {/* compromises. Hence we are just hiding the content of the page */}
+        {/* until the first client side render, at which time the document */}
+        {/* object is available. */}
+        {/* TODO: Remove this hackfix to ensure that pre-rendered pages' */}
+        {/*       SEO performance is not impacted. */}
+        <body style={{ visibility: "hidden" }}>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default LiikuntDocument;


### PR DESCRIPTION
I tried my hardest to avoid creating a custom server. A custom server would remove some Next features and optimizations.

I was able to find this approach where we create a fake document and then attempt to reset it between requests.

This is a bandaid fix in that the document is not created per request. I wasn't able to find a better way to hook into the application logic early enough.

The ideal fix would be to add SSR support into HDS. 