### PR TITLE
Fix revalidation configuration for ISR

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -181,7 +181,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
   return {
     props: {
       initialApolloState: cmsClient.cache.extract(),
-      revalidate: 1,
     },
+    revalidate: 10,
   };
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -114,7 +114,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
   return {
     props: {
       initialApolloState: cmsClient.cache.extract(),
-      revalidate: 1,
     },
+    revalidate: 10,
   };
 }


### PR DESCRIPTION
Revalidation had been accidentally declared within the props.

This meant that pages would never be re-built.

This would result in build time data always being used.