### PR TITLE
Liikunta 75 | Add upcoming events section

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -45,11 +45,12 @@ function CardTitle({ href, title, ...textProps }: CardTitleProps) {
 
 type CardPreProps = {
   children: ReactNode;
+  className?: string;
 };
 
-function CardPre({ children }: CardPreProps) {
+function CardPre({ children, className }: CardPreProps) {
   return (
-    <Text variant="body-l" className={styles.pre}>
+    <Text variant="body-l" className={classNames(styles.pre, className)}>
       {children}
     </Text>
   );

--- a/src/components/card/CondensedCard.tsx
+++ b/src/components/card/CondensedCard.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import { Item } from "../../types";
+import Card from "./Card";
+import styles from "./condensedCard.module.scss";
+
+function CondensedCard({
+  id,
+  title,
+  infoLines,
+  keywords,
+  pre,
+  href,
+  image,
+}: Item) {
+  return (
+    <Card id={id}>
+      <Card.Content className={styles.content}>
+        <Card.Title title={title} href={href} as="h3" variant="h3" />
+        <Card.Pre className={styles.pre}>{pre}</Card.Pre>
+        <Card.InfoLines infoLines={infoLines} />
+      </Card.Content>
+      <Card.Keywords keywords={keywords} className={styles.keywords} />
+      <Card.Image image={image} />
+    </Card>
+  );
+}
+
+export default CondensedCard;

--- a/src/components/card/condensedCard.module.scss
+++ b/src/components/card/condensedCard.module.scss
@@ -26,6 +26,5 @@
 
   @include breakpoints.respond-above(m) {
     padding: $spacing-m !important;
-    padding-top: $spacing-m !important;
   }
 }

--- a/src/components/card/condensedCard.module.scss
+++ b/src/components/card/condensedCard.module.scss
@@ -1,20 +1,31 @@
+@use "breakpoints";
 @import "variables";
 
 .keywords {
-  padding: $spacing-m !important;
-  padding-bottom: 0 !important;
+  @include breakpoints.respond-above(m) {
+    padding: $spacing-m !important;
+    padding-bottom: 0 !important;
 
-  & li {
-    transform: translateY(50%);
+    & li {
+      transform: translateY(50%);
+    }
   }
 }
 
 .pre {
-  margin-top: 0.25rem;
-
   font-weight: 400 !important;
+
+  @include breakpoints.respond-above(m) {
+    // Add a slight margin to offset the keywords which overflow their container
+    margin-top: 0.25rem;
+  }
 }
 
 .content {
-  padding: $spacing-m !important;
+  padding-top: $spacing-s !important;
+
+  @include breakpoints.respond-above(m) {
+    padding: $spacing-m !important;
+    padding-top: $spacing-m !important;
+  }
 }

--- a/src/components/card/condensedCard.module.scss
+++ b/src/components/card/condensedCard.module.scss
@@ -1,0 +1,20 @@
+@import "variables";
+
+.keywords {
+  padding: $spacing-m !important;
+  padding-bottom: 0 !important;
+
+  & li {
+    transform: translateY(50%);
+  }
+}
+
+.pre {
+  margin-top: 0.25rem;
+
+  font-weight: 400 !important;
+}
+
+.content {
+  padding: $spacing-m !important;
+}

--- a/src/components/layout/layout.module.scss
+++ b/src/components/layout/layout.module.scss
@@ -1,21 +1,15 @@
 @use "breakpoints";
+@use "utils";
 @import "variables";
 
 .Layout {
-  // Custom non-HDS compliant max width for content. Breaks alignment with
-  // for instance Navigation.
-  --liikunta-width: 100rem; // 1600px
   --spacing: #{$spacing-layout-2-xs};
-  --content-width: calc(var(--liikunta-width) - 2 * #{$spacing-layout-xs});
 
   display: grid;
   // Set a three column layout where the middle column is the content column
-  // that has a max width of --content-width and two whitespace columns with a
+  // that has a max width of size param and two whitespace columns with a
   // mininum width of --spacing.
-  grid-template-columns:
-    minmax(var(--spacing), auto)
-    minmax(auto, var(--content-width))
-    minmax(var(--spacing), auto);
+  @include utils.get-layout-columns(m);
   grid-template-rows: auto;
 
   & > * {

--- a/src/components/list/List.tsx
+++ b/src/components/list/List.tsx
@@ -5,12 +5,23 @@ import styles from "./list.module.scss";
 
 type Props = {
   items: React.ReactElement[];
-  variant?: "default" | "collection-grid" | "tight" | "searchResult";
+  variant?:
+    | "default"
+    | "collection-grid"
+    | "tight"
+    | "searchResult"
+    | "columns-3";
 };
 
 function List({ items, variant = "default" }: Props) {
   return (
-    <ul className={classNames(styles.list, styles[variant])}>
+    <ul
+      className={classNames({
+        [styles.list]: variant !== "columns-3",
+        [styles[variant]]: variant !== "columns-3",
+        [styles["columns-3"]]: variant === "columns-3",
+      })}
+    >
       {items.map((node: React.ReactElement) => (
         <li key={node.key} className={styles.item}>
           {node}

--- a/src/components/list/list.module.scss
+++ b/src/components/list/list.module.scss
@@ -77,7 +77,7 @@
   padding: 0;
   list-style-type: none;
 
-  columns: 3 calc(24.5rem - (#{$spacing-m} / 2));
+  columns: calc(24.5rem - (#{$spacing-m} * 0.5)) 3;
   column-gap: $spacing-m;
 
   & > * {

--- a/src/components/list/list.module.scss
+++ b/src/components/list/list.module.scss
@@ -71,3 +71,18 @@
 .searchResult {
   grid-template-columns: 1fr;
 }
+
+.columns-3 {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+
+  columns: 3 calc(24.5rem - (#{$spacing-m} / 2));
+  column-gap: $spacing-m;
+
+  & > * {
+    display: inline-block;
+    margin-bottom: $spacing-m;
+    width: 100%;
+  }
+}

--- a/src/components/section/Section.tsx
+++ b/src/components/section/Section.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import React from "react";
 import classNames from "classnames";
+import { Koros } from "hds-react";
 
 import Text from "../text/Text";
 import SecondaryLink from "../link/SecondaryLink";
@@ -15,6 +16,8 @@ type Props = {
   };
   color?: "grey" | "white" | "transparent";
   variant?: "default" | "contained";
+  koros?: "none" | React.ComponentProps<typeof Koros>["type"];
+  contentWidth?: "m" | "s";
 };
 
 function Section({
@@ -23,13 +26,24 @@ function Section({
   cta,
   color = "grey",
   variant = "default",
+  koros = "none",
+  contentWidth = "m",
 }: Props) {
   const titleComponent = <Text variant="h2">{title}</Text>;
 
   return (
     <section
-      className={classNames(styles.section, styles[color], styles[variant])}
+      className={classNames(
+        styles.section,
+        styles[color],
+        styles[variant],
+        styles[contentWidth],
+        {
+          [styles.hasKoros]: koros !== "none",
+        }
+      )}
     >
+      {koros !== "none" && <Koros className={styles.koros} type={koros} />}
       {!cta && title && titleComponent}
       {cta && title && (
         <header className={styles.sectionHeader}>

--- a/src/components/section/section.module.scss
+++ b/src/components/section/section.module.scss
@@ -1,4 +1,5 @@
 @use "breakpoints";
+@use "utils";
 @import "variables";
 
 .section {
@@ -11,6 +12,7 @@
   grid-template-rows: inherit;
   row-gap: $spacing-layout-m;
   padding: var(--section-padding) 0;
+  position: relative;
 
   background: var(--section-background);
 
@@ -26,9 +28,28 @@
     --section-padding: 0;
   }
 
+  &.hasKoros {
+    margin-top: 85px; // height of Koros
+  }
+
+  &.s {
+    @include utils.get-layout-columns(s);
+  }
+
   &:last-child {
     // even out footer koros margin
     padding-bottom: $spacing-layout-m + 1rem;
+  }
+
+  & .koros {
+    grid-column: 1 / -1;
+    position: absolute;
+    bottom: 100%;
+    left: 0;
+    right: 0;
+
+    transform: translateY(50%);
+    fill: var(--section-background);
   }
 
   & > * {

--- a/src/pages/entities/[id].tsx
+++ b/src/pages/entities/[id].tsx
@@ -25,6 +25,7 @@ import Hr from "../../components/hr/Hr";
 import Section from "../../components/section/Section";
 import List from "../../components/list/List";
 import Card from "../../components/card/DefaultCard";
+import CondensedCard from "../../components/card/CondensedCard";
 import styles from "./entity.module.scss";
 import { Item, Recommendation } from "../../types";
 
@@ -69,7 +70,7 @@ export default function EntityPage() {
   const name = "Eiran uimaranta";
   const streetAddress = "Eiranranta 3";
   const recommendationItems = getRecommendationsAsItems(
-    [...mockRecommendations, ...mockRecommendations.slice(0, 2)],
+    mockRecommendations,
     router
   );
 
@@ -260,8 +261,14 @@ export default function EntityPage() {
       <Section title="Seuravat tapahtumat" koros="storm" contentWidth="s">
         <List
           variant="columns-3"
-          items={recommendationItems.map((item) => (
-            <Card key={item.id} {...item} />
+          items={[
+            ...recommendationItems,
+            ...recommendationItems.slice(0, 2).map(({ id, ...rest }) => ({
+              ...rest,
+              id: `${id}-b`,
+            })),
+          ].map((item) => (
+            <CondensedCard key={item.id} {...item} />
           ))}
         />
       </Section>

--- a/src/pages/entities/[id].tsx
+++ b/src/pages/entities/[id].tsx
@@ -69,10 +69,9 @@ export default function EntityPage() {
   const name = "Eiran uimaranta";
   const streetAddress = "Eiranranta 3";
   const recommendationItems = getRecommendationsAsItems(
-    mockRecommendations,
+    [...mockRecommendations, ...mockRecommendations.slice(0, 2)],
     router
   );
-  console.log(recommendationItems);
 
   return (
     <Page
@@ -258,6 +257,14 @@ export default function EntityPage() {
           </div>
         </div>
       </article>
+      <Section title="Seuravat tapahtumat" koros="storm" contentWidth="s">
+        <List
+          variant="columns-3"
+          items={recommendationItems.map((item) => (
+            <Card key={item.id} {...item} />
+          ))}
+        />
+      </Section>
       <Section title="Muuta samankaltaista liikuntaa" color="white">
         <List
           items={recommendationItems.map((item) => (

--- a/src/styles/utils.scss
+++ b/src/styles/utils.scss
@@ -1,0 +1,26 @@
+@import "variables";
+
+$sizes: (
+  s: $breakpoint-xl,
+  // Custom non-HDS compliant max width for content. Breaks alignment with
+  // for instance Navigation.
+  m: 100rem,
+  // 1600px
+);
+
+@function get-content-width($size) {
+  @return calc(#{map-get($sizes, $size)} - 2 * #{$spacing-layout-xs});
+}
+
+@mixin get-layout-columns($size) {
+  @if map-has-key($sizes, $size) {
+    $content-width: get-content-width($size);
+
+    grid-template-columns:
+      minmax(var(--spacing), auto)
+      minmax(auto, #{$content-width})
+      minmax(var(--spacing), auto);
+  } @else {
+    @warn 'Invalid size: #{$size}.';
+  }
+}

--- a/src/tests/TestProviders.tsx
+++ b/src/tests/TestProviders.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { RouterContext } from "next/dist/next-server/lib/router-context";
+import { NextRouter } from "next/router";
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+
+const mockRouter: NextRouter = {
+  basePath: "",
+  pathname: "/",
+  route: "/",
+  asPath: "/",
+  query: {},
+  push: jest.fn(() => Promise.resolve(true)),
+  prefetch: jest.fn(() => Promise.resolve()),
+  replace: jest.fn(() => Promise.resolve(true)),
+  back: jest.fn(() => Promise.resolve(true)),
+  reload: jest.fn(() => Promise.resolve(true)),
+  beforePopState: jest.fn(() => Promise.resolve(true)),
+  events: {
+    on: jest.fn(),
+    off: jest.fn(),
+    emit: jest.fn(),
+  },
+  isFallback: false,
+  isLocaleDomain: true,
+  isPreview: false,
+  isReady: true,
+  locale: "fi",
+  defaultLocale: "fi",
+};
+
+type Props = {
+  mocks?: ReadonlyArray<MockedResponse>;
+  children: React.ReactNode;
+};
+
+function TestProviders({ mocks, children }: Props) {
+  return (
+    <RouterContext.Provider value={mockRouter}>
+      <MockedProvider mocks={mocks} addTypename={false}>
+        {children}
+      </MockedProvider>
+    </RouterContext.Provider>
+  );
+}
+
+export default TestProviders;

--- a/src/tests/entities/[id].test.jsx
+++ b/src/tests/entities/[id].test.jsx
@@ -1,0 +1,43 @@
+import { act } from "react-dom/test-utils";
+
+import { PAGE_QUERY } from "../../components/page/Page";
+import EntityPage from "../../pages/entities/[id]";
+import { render, screen, waitFor } from "../utils";
+import mockMenus from "../mockData/mockMenus";
+
+const getMocks = () => [
+  {
+    request: {
+      query: PAGE_QUERY,
+      variables: {
+        menuLocation: "PRIMARY",
+      },
+    },
+    response: {
+      pageLanguages: [
+        {
+          id: "1",
+          name: "English",
+          slug: "en",
+          code: "EN",
+          locale: "en_US",
+        },
+      ],
+      pageMenus: mockMenus,
+    },
+  },
+];
+
+describe("entities/[id]", () => {
+  it("renders without crashing", async () => {
+    await act(async () => {
+      render(<EntityPage />, getMocks());
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("Eiran uimaranta", { selector: "h2" })
+      ).toBeInTheDocument()
+    );
+  });
+});

--- a/src/tests/index.test.tsx
+++ b/src/tests/index.test.tsx
@@ -1,9 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { RouterContext } from "next/dist/next-server/lib/router-context";
-import { NextRouter } from "next/router";
-import { MockedProvider } from "@apollo/client/testing";
 import { act } from "react-dom/test-utils";
 
+import { render, screen, waitFor } from "./utils";
 import App, { LANDING_PAGE_QUERY } from "../pages/index";
 import { PAGE_QUERY } from "../components/page/Page";
 import mockLandingPage from "./mockData/landingPage";
@@ -50,41 +47,10 @@ const getMocks = () => [
   },
 ];
 
-const mockRouter: NextRouter = {
-  basePath: "",
-  pathname: "/",
-  route: "/",
-  asPath: "/",
-  query: {},
-  push: jest.fn(() => Promise.resolve(true)),
-  prefetch: jest.fn(() => Promise.resolve()),
-  replace: jest.fn(() => Promise.resolve(true)),
-  back: jest.fn(() => Promise.resolve(true)),
-  reload: jest.fn(() => Promise.resolve(true)),
-  beforePopState: jest.fn(() => Promise.resolve(true)),
-  events: {
-    on: jest.fn(),
-    off: jest.fn(),
-    emit: jest.fn(),
-  },
-  isFallback: false,
-  isLocaleDomain: true,
-  isPreview: false,
-  isReady: true,
-  locale: "fi",
-  defaultLocale: "fi",
-};
-
 describe("App", () => {
   it("renders without crashing", async () => {
     await act(async () => {
-      render(
-        <RouterContext.Provider value={mockRouter}>
-          <MockedProvider mocks={getMocks()} addTypename={false}>
-            <App />
-          </MockedProvider>
-        </RouterContext.Provider>
-      );
+      render(<App />, getMocks());
     });
 
     await waitFor(() =>

--- a/src/tests/utils.tsx
+++ b/src/tests/utils.tsx
@@ -1,0 +1,23 @@
+import React, { ReactElement } from "react";
+import { render, RenderOptions } from "@testing-library/react";
+import { MockedResponse } from "@apollo/client/testing";
+
+import TestProviders from "./TestProviders";
+
+const customRender = (
+  ui: ReactElement,
+  mocks?: MockedResponse[],
+  options?: RenderOptions
+) =>
+  render(ui, {
+    wrapper: ({ children }) => (
+      <TestProviders mocks={mocks}>{children}</TestProviders>
+    ),
+    ...options,
+  });
+
+// re-export everything
+export * from "@testing-library/react";
+
+// override render method
+export { customRender as render };


### PR DESCRIPTION
I was able to use columns for this layout after all. The trick was to use `display: inline-block` on the element that appear as a child of the column container.

I also tried to use `flex`, but it would have required a fixed height to be set, which would have made reusability very difficult to do.

I implemented a new card type in order to comply with the desing.

<img width="1291" alt="Screenshot 2021-06-09 at 14 52 36" src="https://user-images.githubusercontent.com/9090689/121349575-5a920980-c932-11eb-8e31-2febeaf3717d.png">
