### PR TITLE
Fix CMS integration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,4 @@
-NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT=https://liikunta.hkih.production.geniem.io/graphql
+NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT=https://liikunta.content.api.hel.fi/graphql
 NEXT_PUBLIC_UNIFIED_SEARCH_GRAPHQL_ENDPOINT=https://unified-search.test.kuva.hel.ninja/search
 NEXT_PUBLIC_NEXT_API_GRAPHQL_ENDPOINT=http://localhost:3000/api/graphql/
 NEXT_PUBLIC_DEBUG=1

--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,3 @@
-NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT=https://liikunta.hkih.production.geniem.io/graphql
+NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT=https://liikunta.content.api.hel.fi/graphql
 NEXT_PUBLIC_UNIFIED_SEARCH_GRAPHQL_ENDPOINT=https://unified-search.test.kuva.hel.ninja/search
 NEXT_PUBLIC_NEXT_API_GRAPHQL_ENDPOINT=http://localhost:3000/api/graphql/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build application
         run: yarn build
         env:
-          NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: "https://liikunta.hkih.production.geniem.io/graphql"
+          NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: https://liikunta.content.api.hel.fi/graphql
           NEXT_PUBLIC_UNIFIED_SEARCH_GRAPHQL_ENDPOINT: https://unified-search.test.kuva.hel.ninja/search
 
   test:
@@ -62,7 +62,7 @@ jobs:
       - name: Run tests
         run: yarn test --coverage
         env:
-          NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: "https://liikunta.hkih.production.geniem.io/graphql"
+          NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: https://liikunta.content.api.hel.fi/graphql
           NEXT_PUBLIC_UNIFIED_SEARCH_GRAPHQL_ENDPOINT: https://unified-search.test.kuva.hel.ninja/search
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -23,7 +23,7 @@ env:
   K8S_REPLICACOUNT: 2
   K8S_LIVENESS_PATH: /api/healthz
   K8S_READINESS_PATH: /api/readiness
-  NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: https://liikunta.hkih.production.geniem.io/graphql
+  NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: https://liikunta.content.api.hel.fi/graphql
   NEXT_PUBLIC_UNIFIED_SEARCH_GRAPHQL_ENDPOINT: https://unified-search.test.kuva.hel.ninja/search
   NEXT_PUBLIC_NEXT_API_GRAPHQL_ENDPOINT: https://${{ secrets.ENVIRONMENT_URL_STABLE }}/api/graphql
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,7 +18,7 @@ env:
   K8S_LIMIT_RAM: 400Mi
   K8S_LIVENESS_PATH: /api/healthz
   K8S_READINESS_PATH: /api/readiness
-  NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: https://liikunta.hkih.production.geniem.io/graphql
+  NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: https://liikunta.content.api.hel.fi/graphql
   NEXT_PUBLIC_UNIFIED_SEARCH_GRAPHQL_ENDPOINT: https://unified-search.test.kuva.hel.ninja/search
   CUSTOM_ENVIRONMENT_URL: https://liikunta-helsinki-${{ github.event.pull_request.number }}.${{ secrets.BASE_DOMAIN_STAGING }}
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -22,7 +22,7 @@ env:
   K8S_REPLICACOUNT: 2
   K8S_LIVENESS_PATH: /api/healthz
   K8S_READINESS_PATH: /api/readiness
-  NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: https://liikunta.hkih.production.geniem.io/graphql
+  NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: https://liikunta.content.api.hel.fi/graphql
   NEXT_PUBLIC_UNIFIED_SEARCH_GRAPHQL_ENDPOINT: https://unified-search.test.kuva.hel.ninja/search
   NEXT_PUBLIC_NEXT_API_GRAPHQL_ENDPOINT: https://${{ secrets.ENVIRONMENT_URL_STAGING }}/api/graphql
 

--- a/src/client/cmsApolloClient.ts
+++ b/src/client/cmsApolloClient.ts
@@ -26,18 +26,6 @@ function createCmsApolloClient() {
             },
           },
         },
-        MediaItem: {
-          fields: {
-            mediaItemUrl: {
-              // For some reason the GraphQL endpoint isn't able to return image
-              // data.
-              read() {
-                // eslint-disable-next-line max-len
-                return "https://liikunta.hkih.production.geniem.io/uploads/sites/2/2021/05/097b0788-hkms000005_km00390n-scaled.jpeg";
-              },
-            },
-          },
-        },
       },
     }),
   });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -35,13 +35,17 @@ export const LANDING_PAGE_QUERY = gql`
     }
     landingPage(id: "root", idType: SLUG) {
       id
+      desktopImage {
+        edges {
+          node {
+            mediaItemUrl
+          }
+        }
+      }
       translation(language: $languageCode) {
         title
         description
         heroLink
-        desktopImage {
-          mediaItemUrl
-        }
       }
     }
   }
@@ -108,12 +112,14 @@ export default function Home() {
     data?.collections ?? emptyConnection
   );
   const categories = mockCategories;
+  const heroImage =
+    data?.landingPage?.desktopImage?.edges[0]?.node?.mediaItemUrl;
 
   return (
     <Page title="Liikunta-Helsinki" description="Liikunta-helsinki">
       {landingPage && (
         <>
-          <HeroImage desktopImageUri={landingPage.desktopImage?.mediaItemUrl} />
+          <HeroImage desktopImageUri={heroImage} />
           <Section variant="contained" color="transparent">
             <Hero
               title={landingPage.title}

--- a/src/tests/index.test.tsx
+++ b/src/tests/index.test.tsx
@@ -18,10 +18,7 @@ const getMocks = () => [
     result: {
       data: {
         collections: { edges: [] },
-        landingPage: {
-          id: "sdkjfn1",
-          translation: mockLandingPage,
-        },
+        landingPage: mockLandingPage,
       },
     },
   },

--- a/src/tests/mockData/landingPage.ts
+++ b/src/tests/mockData/landingPage.ts
@@ -1,11 +1,18 @@
 const mockLandingPage = {
-  title: "Kesän parhaat uimarannat",
-  description: "Kokosimme yhteen",
+  id: "sdkjfn1",
   desktopImage: {
-    mediaItemUrl:
-      "https://liikunta.hkih.production.geniem.io/uploads/sites/2/2021/05/097b0788-hkms000005_km00390n-scaled.jpeg",
+    edges: {
+      node: {
+        mediaItemUrl:
+          "https://liikunta.hkih.production.geniem.io/uploads/sites/2/2021/05/097b0788-hkms000005_km00390n-scaled.jpeg",
+      },
+    },
   },
-  heroLink: ["Katso vinkit", "/tips/uimarannat"],
+  translation: {
+    title: "Kesän parhaat uimarannat",
+    description: "Kokosimme yhteen",
+    heroLink: ["Katso vinkit", "/tips/uimarannat"],
+  },
 };
 
 export default mockLandingPage;


### PR DESCRIPTION
The Graphql CMS API was updated and it broke our integration.

The `dekstopImage` query for landing page does not return the image I expected. I've sent a question about this to Geniem.