### PR TITLE
Fetch collections from root page

### DIFF
--- a/src/tests/index.test.tsx
+++ b/src/tests/index.test.tsx
@@ -12,13 +12,12 @@ const getMocks = () => [
       query: LANDING_PAGE_QUERY,
       variables: {
         languageCode: "FI",
-        languageCodeFilter: "FI",
       },
     },
     result: {
       data: {
-        collections: { edges: [] },
         landingPage: mockLandingPage,
+        pageBy: { modules: [] },
       },
     },
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,9 +63,11 @@ export type Connection<T> = {
 
 export type Collection = {
   id: string;
-  title: string;
-  description: string;
-  image: string;
+  translation?: {
+    title?: string;
+    description?: string;
+    image?: string;
+  };
 };
 
 export type LocalizedString = {


### PR DESCRIPTION
Don't fetch collections from the connection resolver, instead fetch collections that have been selected to be shown on the front page.