### PR TITLE
LIIKUNTA-92 | Limit search results to sports locations

### DIFF
--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -23,6 +23,10 @@ import styles from "./search.module.scss";
 import { Locale } from "../../config";
 
 const BLOCK_SIZE = 10;
+// And ID that matches the sports ontology tree branch that has the Culture,
+// sports and leisure department (KuVa) as its parent.
+// https://www.hel.fi/palvelukarttaws/rest/v4/ontologytree/551
+const SPORTS_DEPARTMENT_ONTOLOGY_TREE_ID = 551;
 
 export const SEARCH_QUERY = gql`
   query SearchQuery(
@@ -30,6 +34,7 @@ export const SEARCH_QUERY = gql`
     $first: Int
     $cursor: String
     $language: UnifiedSearchLanguage!
+    $ontologyTreeId: ID!
   ) {
     unifiedSearch(
       q: $q
@@ -37,6 +42,7 @@ export const SEARCH_QUERY = gql`
       first: $first
       after: $cursor
       languages: [$language]
+      ontologyTreeId: $ontologyTreeId
     ) {
       count
       pageInfo {
@@ -122,6 +128,7 @@ export default function Search() {
       first: BLOCK_SIZE,
       after: "",
       language: appToUnifiedSearchLanguageMap[locale],
+      ontologyTreeId: SPORTS_DEPARTMENT_ONTOLOGY_TREE_ID,
     },
     fetchPolicy: "cache-and-network",
   });


### PR DESCRIPTION
Instead of searching from all locations, search from location which are marked to be under liikunta's "jurisdiction".

In this PR we take into use the `ontologyTreeId` filter and use it to target liikunta locations.

The three looks something like this:

```
KuVa
 - One
 - Two
 - Liikunta (id: 551)
```