### PR TITLE
Fix small bugs

### DIFF
--- a/src/domain/graphql/dataSources/Hauki.ts
+++ b/src/domain/graphql/dataSources/Hauki.ts
@@ -74,16 +74,12 @@ export default class Hauki extends RESTDataSource {
     params.append("end_date", ongoingWeekInterval.end.toJSON());
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await this.get<any>(
+    const data = await this.get<any>(
       `resource/${id}/opening_hours/?${params.toString()}`
     );
 
-    if (res.statusText !== "OK") {
-      return null;
-    }
-
     const transformedOpeningHours = toCamelCase<OpeningHour[]>(
-      patchMissingDates(ongoingWeekInterval, res?.data, (date: Date) => ({
+      patchMissingDates(ongoingWeekInterval, data, (date: Date) => ({
         date: lightFormat(date, "yyyy-MM-dd"),
         times: [],
       }))
@@ -101,8 +97,8 @@ export default class Hauki extends RESTDataSource {
    */
   async getIsOpen(id: string): Promise<boolean | null> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const res = await this.get<any>(`resource/${id}/is_open_now/`);
+    const data = await this.get<any>(`resource/${id}/is_open_now/`);
 
-    return res?.data?.is_open ?? null;
+    return data?.is_open ?? null;
   }
 }

--- a/src/domain/graphql/dataSources/Linked.ts
+++ b/src/domain/graphql/dataSources/Linked.ts
@@ -110,6 +110,7 @@ export default class Linked extends RESTDataSource {
     params.set("start", "now");
     params.set("location", id);
     params.set("sort", "start_time");
+    params.set("super_event_type", "none");
 
     if (language) {
       params.set("language", language);

--- a/src/domain/graphql/dataSources/Linked.ts
+++ b/src/domain/graphql/dataSources/Linked.ts
@@ -109,6 +109,7 @@ export default class Linked extends RESTDataSource {
     const params = new URLSearchParams();
     params.set("start", "now");
     params.set("location", id);
+    params.set("sort", "start_time");
 
     if (language) {
       params.set("language", language);

--- a/src/domain/graphql/dataSources/Tprek.ts
+++ b/src/domain/graphql/dataSources/Tprek.ts
@@ -34,22 +34,10 @@ export default class Tprek extends RESTDataSource {
   }
 
   private async getAllOntologyWords() {
-    const res = await this.get(`ontologyword/`);
-
-    if (res.statusText !== "OK") {
-      return null;
-    }
-
-    return res.data;
+    return this.get(`ontologyword/`);
   }
 
   private async getOntologyTrees() {
-    const res = await this.get(`ontologytree/`);
-
-    if (res.statusText !== "OK") {
-      return null;
-    }
-
-    return res.data;
+    return this.get(`ontologytree/`);
   }
 }

--- a/src/domain/i18nRouter/useRouter.ts
+++ b/src/domain/i18nRouter/useRouter.ts
@@ -4,6 +4,7 @@ import { getI18nPath, stringifyUrlObject } from "./utils";
 
 export default function useRouter() {
   const { asPath, ...router } = useNextRouter();
+  const search = asPath.split("?")[1];
 
   return {
     ...router,
@@ -11,6 +12,7 @@ export default function useRouter() {
       stringifyUrlObject({
         pathname: getI18nPath(router.route, router.locale),
         query: router.query,
+        search: `?${search}`,
       }) ?? asPath,
   };
 }

--- a/src/domain/i18nRouter/utils.ts
+++ b/src/domain/i18nRouter/utils.ts
@@ -44,10 +44,12 @@ const isDynamic = (part: string) => part.startsWith("[") && part.endsWith("]");
 const parseDynamicName = (part: string) => part.slice(1, -1);
 
 export function stringifyUrlObject(url: UrlObject): string {
-  return url.pathname
+  const pathname = url.pathname
     ?.split("/")
     .map((part) =>
       isDynamic(part) ? url.query[parseDynamicName(part)] ?? part : part
     )
     .join("/");
+
+  return `${pathname}${url.search || ""}`;
 }

--- a/src/domain/i18nRouter/utils.ts
+++ b/src/domain/i18nRouter/utils.ts
@@ -24,7 +24,7 @@ export function getI18nPath(route: string, locale: string): string {
     )?.[1] ?? [];
 
   if (!i18nRewriteRules || i18nRewriteRules.length === 0) {
-    return null;
+    return route;
   }
 
   const i18nRewriteRuleForCurrentLocale = i18nRewriteRules.find(
@@ -32,7 +32,7 @@ export function getI18nPath(route: string, locale: string): string {
   );
 
   if (!i18nRewriteRuleForCurrentLocale) {
-    return null;
+    return route;
   }
 
   return transformDynamicPathIntoSegmentedDynamicPath(

--- a/src/util/events/getEventsAsItems.ts
+++ b/src/util/events/getEventsAsItems.ts
@@ -110,7 +110,6 @@ export default function getEventsAsItems(events?: Event[]): Item[] {
       id,
       name,
       shortDescription,
-      infoUrl,
       images,
       offers: [offer],
     } = event;
@@ -123,7 +122,7 @@ export default function getEventsAsItems(events?: Event[]): Item[] {
       keywords: [getIsCloseInTimeKeyword(event), getIsFree(event)].filter(
         (item) => item
       ),
-      href: infoUrl,
+      href: `https://tapahtumat.hel.fi/fi/events/${id}`,
       image: images?.[0]?.url,
     };
   });

--- a/src/util/time/humanizeOpeningHoursForWeek.ts
+++ b/src/util/time/humanizeOpeningHoursForWeek.ts
@@ -165,10 +165,6 @@ function humanizeTime(time: Time, copy = microCopy.fi): string {
 }
 
 function humanizeTimes(times: Time[], copy = microCopy.fi): string {
-  if (times.length === 0) {
-    return copy.closed;
-  }
-
   return times.map((time) => humanizeTime(time, copy)).join(", ");
 }
 
@@ -240,6 +236,10 @@ function humanizeOpeningHoursForWeek(
   );
 
   if (matchingTimes) {
+    if (matchingTimes.length === 0) {
+      return null;
+    }
+
     const commonTimes = humanizeTimes(matchingTimes, microCopy[locale]);
     const weekendOpeningHours = [sat, sun].map((weekendOpeningHour) =>
       humanizeOpeningHour(weekendOpeningHour, locale)


### PR DESCRIPTION
In this PR I fix small bugs or slightly adjust behaviour based on comments.

**Fix datasources that assume a response object instead of respond data**  
When refactoring into using Apollo's DataSource class, the return type of the `get` method changed from an axios response to the data field within that response. This change fixes the incorrect assumption that a response object is returned.

This fixes issues with "ontologies" and opening hours.

**Don't treat empty hours as closed**  
When times were missing for dates and dates were grouped, those times were treated as closed. They should not have been treated as closed, instead they should have been treated as unknown. If times are missing, opening hours for that date are not shown.

* Fix `asPath` missing query when using the i18n friendly `useRouter`
* Fix localisation of routes that do not have rewrite rules
* Order recommended events by start time
* Exclude super events from recommended events
* Use links for events which redirect the user to tapahtumat Helsinki