### PR TITLE
Use a grid instead of columns for upcoming events

### DIFF
--- a/src/components/list/List.tsx
+++ b/src/components/list/List.tsx
@@ -10,19 +10,13 @@ type Props = {
     | "collection-grid"
     | "tight"
     | "searchResult"
-    | "columns-3"
+    | "grid-3"
     | "grid-2";
 };
 
 function List({ items, variant = "default" }: Props) {
   return (
-    <ul
-      className={classNames({
-        [styles.list]: variant !== "columns-3",
-        [styles[variant]]: variant !== "columns-3",
-        [styles["columns-3"]]: variant === "columns-3",
-      })}
-    >
+    <ul className={classNames(styles.list, styles[variant])}>
       {items.map((node: React.ReactElement) => (
         <li key={node.key} className={styles.item}>
           {node}

--- a/src/components/list/list.module.scss
+++ b/src/components/list/list.module.scss
@@ -76,18 +76,8 @@
   --base-list-item-width: 32rem; // 512px
 }
 
-.columns-3 {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
+.grid-3 {
+  --base-list-item-width: calc(24.5rem - (#{$spacing-m} * 0.5));
 
-  column-count: 3;
-  column-width: calc(24.5rem - (#{$spacing-m} * 0.5));
-  column-gap: $spacing-m;
-
-  & > * {
-    display: inline-block;
-    margin-bottom: $spacing-m;
-    width: 100%;
-  }
+  grid-gap: $spacing-m;
 }

--- a/src/widgets/upcomingEventsSection/UpcomingEventsSection.tsx
+++ b/src/widgets/upcomingEventsSection/UpcomingEventsSection.tsx
@@ -55,7 +55,7 @@ export default function UpcomingEventsSection({ linkedId }: Props) {
   return (
     <Section title="Seuravat tapahtumat" koros="storm" contentWidth="s">
       <List
-        variant="columns-3"
+        variant="grid-3"
         items={eventItems.map((item) => (
           <CondensedCard key={item.id} {...item} />
         ))}


### PR DESCRIPTION
Use a grid instead of columns to get a left-to-right order instead of a column order for upcoming events.