### PR TITLE
LIIKUNTA-124 | Fix search term not resetting in the UI

### DIFF
--- a/src/domain/unifiedSearch/useSearchParameters.ts
+++ b/src/domain/unifiedSearch/useSearchParameters.ts
@@ -15,7 +15,7 @@ function stringifyQueryValue(value: string | string[]): string {
 
 export default function useSearchParameters() {
   const {
-    query: { q = "*", administrativeDivisionId },
+    query: { q, administrativeDivisionId },
   } = useRouter();
 
   return {

--- a/src/domain/unifiedSearch/useSearchQuery.ts
+++ b/src/domain/unifiedSearch/useSearchQuery.ts
@@ -33,7 +33,11 @@ export default function useSearchQuery<TData = any>(
     "variables"
   >
 ) {
-  const { q, administrativeDivisionId, ontologyTreeId } = useSearchParameters();
+  const {
+    q = "*",
+    administrativeDivisionId,
+    ontologyTreeId,
+  } = useSearchParameters();
   const router = useRouter();
   const locale = router.locale ?? router.defaultLocale;
   const { fetchMore, ...delegated } = useQuery(query, {


### PR DESCRIPTION
Previously the search term would not reset on language change. This change forces the value to synchronise with search parameter values. The approach is not ideal, but I would not think of another small fix to resolve the issue.