### PR TITLE
LIIKUNTA-126 | Fix map searches redirecting to list view

### DIFF
--- a/i18nRoutes.config.js
+++ b/i18nRoutes.config.js
@@ -3,6 +3,10 @@ const i18nRoutes = {
     { source: "/haku", locale: "fi" },
     { source: "/sok", locale: "sv" },
   ],
+  "/search/map": [
+    { source: "/haku/kartta", locale: "fi" },
+    { source: "/sok/karta", locale: "sv" },
+  ],
   "/venues/:id": [
     { source: "/paikat/:id", locale: "fi" },
     { source: "/platser/:id", locale: "sv" },

--- a/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -35,13 +35,14 @@ const SUGGESTION_QUERY = gql`
 
 type Props = {
   showTitle?: boolean;
+  searchRoute?: "/search" | "/search/map";
 };
 
-function SearchPageSearchForm({ showTitle = true }: Props) {
+function SearchPageSearchForm({ showTitle = true, searchRoute }: Props) {
   const { t } = useTranslation("search_page_search_form");
   const searchParameters = useSearchParameters();
   const router = useRouter();
-  const { search } = useSearch();
+  const { search } = useSearch({ searchRoute });
   const [searchText, setSearchText] = useState<string | undefined>(
     searchParameters.q
   );

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -37,11 +37,16 @@ function getQueryString(search: Search): string {
   return new URLSearchParams(searchParamsWithoutEmpty).toString();
 }
 
-function useSearch() {
+type Config = {
+  searchRoute?: "/search" | "/search/map";
+};
+
+function useSearch(config?: Config) {
+  const searchRoute = config?.searchRoute ?? "/search";
   const router = useRouter();
   const searchBasePath =
-    i18nRoutes["/search"].find(({ locale }) => locale === router.locale)
-      ?.source ?? "/search";
+    i18nRoutes[searchRoute].find(({ locale }) => locale === router.locale)
+      ?.source ?? searchRoute;
 
   const getSearchRoute = useCallback(
     (search: Search) => {

--- a/src/pages/search/map.tsx
+++ b/src/pages/search/map.tsx
@@ -122,7 +122,9 @@ export default function MapSearch() {
         showMode={ShowMode.MAP}
         count={count}
         switchShowMode={switchShowMode}
-        searchForm={<SearchPageSearchForm showTitle={false} />}
+        searchForm={
+          <SearchPageSearchForm showTitle={false} searchRoute="/search/map" />
+        }
       />
       <MapView items={searchResultItems} />
     </Page>


### PR DESCRIPTION
Previously searches in the map view of search would redirect the user into the search view. After this change map view searches will stick to the map view.