### PR TITLE
LIIKUNTA-136 | Show opening hour for today in search results

### DIFF
--- a/public/locales/en/search_page.json
+++ b/public/locales/en/search_page.json
@@ -1,4 +1,6 @@
 {
   "show_results_on_map": "EN: Näytä kartalla",
-  "read_more": "EN: Lue lisää"
+  "read_more": "EN: Lue lisää",
+  "block.opening_hours.open_now_label": "EN: Nyt auki",
+  "block.opening_hours.label": "EN: Aukioloaika"
 }

--- a/public/locales/fi/search_page.json
+++ b/public/locales/fi/search_page.json
@@ -1,4 +1,6 @@
 {
   "show_results_on_map": "Näytä kartalla",
-  "read_more": "Lue lisää"
+  "read_more": "Lue lisää",
+  "block.opening_hours.open_now_label": "Nyt auki",
+  "block.opening_hours.label": "Aukioloaika"
 }

--- a/public/locales/sv/search_page.json
+++ b/public/locales/sv/search_page.json
@@ -1,4 +1,6 @@
 {
   "show_results_on_map": "SV: Näytä kartalla",
-  "read_more": "SV: Lue lisää"
+  "read_more": "SV: Lue lisää",
+  "block.opening_hours.open_now_label": "SV: Nyt auki",
+  "block.opening_hours.label": "SV: Aukioloaika"
 }

--- a/src/components/card/searchResultCard.module.scss
+++ b/src/components/card/searchResultCard.module.scss
@@ -18,6 +18,8 @@
   }
 
   .content {
+    width: 100%;
+
     @include breakpoints.respond-above(m) {
       padding-top: 0;
       padding-bottom: $spacing-m;
@@ -53,8 +55,16 @@
 
   .infoBlocks {
     list-style-type: none;
+    display: grid;
     margin: 0;
     padding: 0;
+    width: 100%;
+    gap: $spacing-s;
+
+    @include breakpoints.respond-above(s) {
+      grid-template-columns: 1fr 1fr;
+      gap: $spacing-m;
+    }
   }
 
   @include breakpoints.respond-above(m) {

--- a/src/domain/seo/meta/PageMeta.tsx
+++ b/src/domain/seo/meta/PageMeta.tsx
@@ -3,6 +3,18 @@ import Head from "next/head";
 
 import RouteMeta from "./RouteMeta";
 
+function replaceAll(str: string, find: string, replace: string) {
+  return str.replace(new RegExp(find, "g"), replace);
+}
+
+function unescapeDash(str?: string): string {
+  if (!str) {
+    return str;
+  }
+
+  return replaceAll(str, "&#x2d;", "-");
+}
+
 export type Props = React.ComponentProps<typeof RouteMeta> & {
   // Title of page, required for accessibility: pages should have unique titles
   // so that screen reader users are able to determine when the current page is
@@ -34,7 +46,7 @@ function PageMeta({
   return (
     <>
       <Head>
-        <title>{title}</title>
+        <title>{unescapeDash(title)}</title>
         {description && <meta name="description" content={description} />}
         <meta property="og:title" content={openGraphTitle} />
         {description && (

--- a/src/domain/unifiedSearch/unifiedSearchResultVenueFragment.ts
+++ b/src/domain/unifiedSearch/unifiedSearchResultVenueFragment.ts
@@ -16,6 +16,15 @@ const unifiedSearchVenueFragment = gql`
     images {
       url
     }
+    openingHours {
+      today {
+        startTime
+        endTime
+        endTimeOnNextDay
+        fullDay
+        resourceState
+      }
+    }
     location {
       address {
         streetAddress {

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,9 @@ export type Venue = {
       label: LocalizedString;
     }
   ];
+  openingHours: {
+    today: Time[];
+  };
 };
 
 export type SearchResult = {
@@ -198,6 +201,7 @@ export type AnyObject = Record<string, unknown>;
 
 export type Context = {
   language?: Locale;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dataSources?: any;
 };
 

--- a/src/util/time/humanizeOpeningHoursForWeek.ts
+++ b/src/util/time/humanizeOpeningHoursForWeek.ts
@@ -172,19 +172,25 @@ function getDayOfWeekName(dateTime: string, locale: DateLocale = fi): string {
   return format(new Date(dateTime), "EEEEEE", { locale });
 }
 
-function humanizeOpeningHour(
+export function humanizeOpeningHour(
   openingHour: OpeningHour,
-  locale: Locale = "fi"
+  locale: Locale = "fi",
+  variant: "long" | "short" = "long"
 ): string | null {
   if (openingHour?.times.length === 0) {
     return null;
+  }
+
+  const times = humanizeTimes(openingHour?.times, microCopy[locale]);
+
+  if (variant === "short") {
+    return times;
   }
 
   const dayOfWeekName = getDayOfWeekName(
     openingHour?.date,
     dateLocales[locale]
   );
-  const times = humanizeTimes(openingHour?.times, microCopy[locale]);
 
   return `${dayOfWeekName} ${times}`;
 }


### PR DESCRIPTION
Integrates into the new feature in US that allows for searching for the opening hours for the ongoing day.

Renders the opening hour for the ongoing day in the search results.

<img width="1517" alt="Screenshot 2021-08-30 at 9 22 39" src="https://user-images.githubusercontent.com/9090689/131294512-02e70fc2-0501-4e91-a0ac-a18766f5b624.png">
<img width="1517" alt="Screenshot 2021-08-30 at 9 22 52" src="https://user-images.githubusercontent.com/9090689/131294517-cb058b1c-656b-4635-8e58-32a0120c306b.png">
<img width="1517" alt="Screenshot 2021-08-30 at 9 23 03" src="https://user-images.githubusercontent.com/9090689/131294519-cb8f62e2-2709-496f-8594-a54c38c72fbb.png">
