### PR TITLE
LIIKUNTA-119 | Hide footer on map view

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -12,6 +12,7 @@ function Layout({
   languages,
   menuItems,
   navigationVariant,
+  showFooter = true,
 }: LayoutComponentProps) {
   return (
     <div className={styles.Layout}>
@@ -24,7 +25,7 @@ function Layout({
       <main id={MAIN_CONTENT_ID} className={styles.main}>
         {children}
       </main>
-      <Footer navigationItems={menuItems} />
+      {showFooter && <Footer navigationItems={menuItems} />}
     </div>
   );
 }

--- a/src/components/layout/types.ts
+++ b/src/components/layout/types.ts
@@ -6,6 +6,7 @@ export type LayoutComponentProps = {
   children: React.ReactNode;
   menuItems: NavigationItem[];
   languages: Language[];
+  showFooter?: boolean;
   navigationVariant?: "default" | "white";
 };
 

--- a/src/components/page/Page.tsx
+++ b/src/components/page/Page.tsx
@@ -48,11 +48,13 @@ type Props = Omit<React.ComponentProps<typeof PageMeta>, "languages"> &
   > & {
     children: React.ReactNode;
     layoutComponent?: LayoutComponent;
+    showFooter?: boolean;
   };
 
 function Page({
   children,
   layoutComponent: Layout = DefaultLayout,
+  showFooter,
   navigationVariant,
   ...rest
 }: Props) {
@@ -73,6 +75,7 @@ function Page({
         menuItems={menuItems}
         languages={languages}
         navigationVariant={navigationVariant}
+        showFooter={showFooter}
       >
         {children}
       </Layout>

--- a/src/pages/search/map.tsx
+++ b/src/pages/search/map.tsx
@@ -117,6 +117,7 @@ export default function MapSearch() {
       {...getPageMetaPropsFromSEO(
         mapSearchPageQuery?.data?.page?.translation?.seo
       )}
+      showFooter={false}
     >
       <SearchHeader
         showMode={ShowMode.MAP}


### PR DESCRIPTION
Added a prop to `Page` component that hides the footer. Passing a prop through one extra component might not be ideal but imo it's clearer than adding a direct check to `Layout` component that checks if the url path matches the map view.