### PR TITLE
LIIKUNTA-130 | Fix administrativeDivisionId being passed as undefined

### DIFF
--- a/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/components/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -63,7 +63,12 @@ function SearchPageSearchForm({ showTitle = true, searchRoute }: Props) {
 
     const q = e.target.q.value;
 
-    doSearch({ q, administrativeDivisionId });
+    doSearch({
+      q,
+      ...(administrativeDivisionId && {
+        administrativeDivisionId,
+      }),
+    });
   };
 
   const handleSearchTextChange = (value: string) => {


### PR DESCRIPTION
If search was executed without selecting administrative division its value would be passed to unified search as undefined resulting to error.  Added a simple check that `administrativeDivisionId` is only passed to search if its selected.