### PR TITLE
LIIKUNTA-118 | Fix wrong scroll position when more events are loaded

### DIFF
--- a/src/domain/pagination/usePagination.tsx
+++ b/src/domain/pagination/usePagination.tsx
@@ -47,7 +47,12 @@ export default function useA11yPagination<
       const result = await fetchMoreBase(fetchMoreOptions);
 
       if (moreResultsAnnouncerRef.current) {
-        moreResultsAnnouncerRef.current.focus();
+        // The announcer element is hidden from visual users and as such may
+        // exist in an unnatural place (visually) on the rendered page. If so,
+        // the browser can scroll into an unexpected position. This is true for
+        // instance when the announcer element is absolutely positioned within
+        // a grid.
+        moreResultsAnnouncerRef.current.focus({ preventScroll: true });
       }
 
       return result;

--- a/src/pages/collections/[slug].tsx
+++ b/src/pages/collections/[slug].tsx
@@ -4,6 +4,7 @@ import { gql, useQuery } from "@apollo/client";
 import Image from "next/image";
 import classNames from "classnames";
 import { useTranslation } from "next-i18next";
+import { LoadingSpinner } from "hds-react";
 
 import { ItemQueryResult } from "../../types";
 import initializeCmsApollo from "../../client/cmsApolloClient";
@@ -30,7 +31,15 @@ type CollectionItemListProps = {
 
 function CollectionItemList({
   title,
-  queryResult: { loading, error, fetchMore, items, pageInfo, totalCount },
+  queryResult: {
+    loading,
+    error,
+    fetchMore,
+    items,
+    pageInfo,
+    totalCount,
+    previousData,
+  },
   pageSize,
 }: CollectionItemListProps) {
   const { t } = useTranslation("collection_page");
@@ -38,6 +47,14 @@ function CollectionItemList({
   // In case of an error, silently fail.
   if (error) {
     return null;
+  }
+
+  if (loading && !previousData) {
+    return (
+      <Section>
+        <LoadingSpinner />
+      </Section>
+    );
   }
 
   // In case there are no events


### PR DESCRIPTION
The load more announcer element was positioned unexpectedly which caused unexpected scroll behaviour.

Because the announcer element was absolutely positioned within the grid, its position on the page was outside the event list itself:
<img width="1013" alt="Screenshot 2021-09-07 at 8 56 35" src="https://user-images.githubusercontent.com/9090689/132291699-8dc096c3-fb29-43e8-af36-ca409363cdde.png">
(Highlighted line is position of the announcer element)

I used the `preventScroll` option of the focus method to prevent scrolling on focus. Evergreen browsers should have support for it.