### PR TITLE
LIIKUNTA-31 | Remove categories from the footer

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -4,9 +4,7 @@ import { useTranslation } from "next-i18next";
 
 import useRouter from "../../domain/i18n/router/useRouter";
 import { NavigationItem } from "../../types";
-import mockCategories from "../../client/tmp/mockCategories";
 import NextLink from "../../domain/i18n/router/Link";
-import SearchShortcuts from "../../components/searchShortcuts/SearchShortcuts";
 import styles from "./footer.module.scss";
 
 type LinkProps = React.HTMLProps<HTMLAnchorElement> & {
@@ -32,7 +30,6 @@ function Footer({ navigationItems }: Props) {
   const { t } = useTranslation("footer");
   const { locale } = useRouter();
   const logoLanguage: LogoLanguage = locale === "sv" ? "sv" : "fi";
-  const categories = mockCategories;
 
   return (
     <HDSFooter
@@ -40,16 +37,6 @@ function Footer({ navigationItems }: Props) {
       className={styles.footer}
       logoLanguage={logoLanguage}
     >
-      <div className={styles.searchShortcuts}>
-        <hr className={styles.hr} aria-hidden="true" />
-        <SearchShortcuts
-          shortcuts={categories.map((category, i) => ({
-            id: i.toString(),
-            label: category.label,
-            icon: category.icon,
-          }))}
-        />
-      </div>
       <HDSFooter.Navigation>
         {navigationItems.map((navigationItem) => (
           <HDSFooter.Item

--- a/src/components/footer/footer.module.scss
+++ b/src/components/footer/footer.module.scss
@@ -20,33 +20,10 @@
 
   // align utility links to right also now when there are no SoMe items
   @include breakpoints.respond-above(m) {
-    > div > div:nth-child(3) {
+    > div > div:nth-child(2) {
       display: grid;
       justify-items: end;
       justify-content: unset;
-    }
-  }
-
-  .hr {
-    background-color: var(--footer-divider-color);
-    border: 0;
-    height: 1px;
-    margin: 0 0 $spacing-xs;
-    width: 100%;
-
-    @include breakpoints.respond-above(m) {
-      margin: 0 0 $spacing-m;
-    }
-  }
-
-  .searchShortcuts {
-    padding: 0 $spacing-m $spacing-m;
-
-    // The footer uses a different content width as compared to the content of
-    // the page. That's why we have to override the base width that's originally
-    // set by the List component.
-    & > ul {
-      --base-list-item-width: 11rem; // 176px
     }
   }
 }


### PR DESCRIPTION
Categories are removed from the footer.

Old version can be found from version control if they are introduced back at some point.

<img width="1680" alt="Screenshot 2021-09-15 at 8 13 43" src="https://user-images.githubusercontent.com/9090689/133374617-1be2408f-43d0-4758-b789-5e055502a318.png">
