### PR TITLE
LIIKUNTA-125 | Add keyword parameter to events query.

### DIFF
--- a/src/domain/events/upcomingEventsSection/UpcomingEventsSection.tsx
+++ b/src/domain/events/upcomingEventsSection/UpcomingEventsSection.tsx
@@ -24,10 +24,11 @@ const UPCOMING_EVENTS_QUERY = gql`
 
 type Props = {
   linkedId: string;
+  keywords: string[];
 };
 
 // This component expects to find the apiApolloClient from Context
-export default function UpcomingEventsSection({ linkedId }: Props) {
+export default function UpcomingEventsSection({ linkedId, keywords }: Props) {
   const { t } = useTranslation("upcoming_events_section");
   const router = useRouter();
   const locale = router.locale ?? router.defaultLocale;
@@ -38,6 +39,7 @@ export default function UpcomingEventsSection({ linkedId }: Props) {
         start: "now",
         sort: "start_time",
         superEventType: "none",
+        keywords: keywords,
       },
       first: 6,
     },

--- a/src/domain/graphql/event/eventSchema.ts
+++ b/src/domain/graphql/event/eventSchema.ts
@@ -10,7 +10,7 @@ const typeDefs = gql`
     language: String
     text: String
     translation: String
-    keywords: [String]
+    keywords: [String!]
   }
 
   extend type Query {

--- a/src/domain/graphql/event/eventSchema.ts
+++ b/src/domain/graphql/event/eventSchema.ts
@@ -10,6 +10,7 @@ const typeDefs = gql`
     language: String
     text: String
     translation: String
+    keywords: [String]
   }
 
   extend type Query {

--- a/src/domain/graphql/services/linked/LinkedDataSource.ts
+++ b/src/domain/graphql/services/linked/LinkedDataSource.ts
@@ -112,6 +112,10 @@ type LinkedEventQuery = {
   pageSize?: number;
 };
 
+// Keywords that target only sport events. Can be array of values, separated by commas.
+// If in the future we have more keywords and want to require all them, change keyword -> keyword_AND
+const SPORT_EVENT_KEYWORDS = ["yso:p916"];
+
 // https://api.hel.fi/linkedevents/v1
 export default class Linked extends RESTDataSource {
   constructor() {
@@ -159,6 +163,8 @@ export default class Linked extends RESTDataSource {
     if (language && !linkedEventQuery.translation) {
       params.set("translation", language);
     }
+
+    params.set("keyword", SPORT_EVENT_KEYWORDS.join(","));
 
     return this.get(`event?${params.toString()}`);
   }

--- a/src/domain/graphql/services/linked/LinkedDataSource.ts
+++ b/src/domain/graphql/services/linked/LinkedDataSource.ts
@@ -110,11 +110,8 @@ type LinkedEventQuery = {
   translation?: string;
   page?: number;
   pageSize?: number;
+  keywords?: string[];
 };
-
-// Keywords that target only sport events. Can be array of values, separated by commas.
-// If in the future we have more keywords and want to require all them, change keyword -> keyword_AND
-const SPORT_EVENT_KEYWORDS = ["yso:p916"];
 
 // https://api.hel.fi/linkedevents/v1
 export default class Linked extends RESTDataSource {
@@ -147,6 +144,10 @@ export default class Linked extends RESTDataSource {
         return params.set("page_size", value.toString());
       }
 
+      if (key === "keywords" && Array.isArray(value)) {
+        return params.set("keyword", value.join(","));
+      }
+
       if (typeof value === "string") {
         params.set(key, value);
       }
@@ -163,8 +164,6 @@ export default class Linked extends RESTDataSource {
     if (language && !linkedEventQuery.translation) {
       params.set("translation", language);
     }
-
-    params.set("keyword", SPORT_EVENT_KEYWORDS.join(","));
 
     return this.get(`event?${params.toString()}`);
   }

--- a/src/pages/venues/[id].tsx
+++ b/src/pages/venues/[id].tsx
@@ -133,6 +133,10 @@ function getGoogleDirectionsUrl(
   return `https://www.google.com/maps/dir/${from}/${to}/`;
 }
 
+// Keywords that target only sport events. Can be array of values, separated by commas.
+// If in the future we have more keywords and want to require all them, change keyword -> keyword_AND
+const SPORT_EVENT_KEYWORDS = ["yso:p916"];
+
 export function VenuePageContent() {
   const { t } = useTranslation("venue_page");
   const router = useRouter();
@@ -452,7 +456,7 @@ export function VenuePageContent() {
           </div>
         </div>
       </article>
-      <UpcomingEventsSection linkedId={id} />
+      <UpcomingEventsSection linkedId={id} keywords={SPORT_EVENT_KEYWORDS} />
     </>
   );
 }


### PR DESCRIPTION
Adds keyword parameter to `linked events` events query. 

Testing:
1) [Review](https://liikunta-helsinki-67.test.kuva.hel.ninja/paikat/tprek:239)
2) [Staging](https://liikunta-helsinki.test.kuva.hel.ninja/paikat/tprek:239)

Seems that the keyword is filtering at least some events, in the testing case "Karanneet eläimet" event should not be shown in the Review environment. 