### PR TITLE
Fix scrolling issue when loading more events

### DIFF
--- a/src/common/apollo/utils.ts
+++ b/src/common/apollo/utils.ts
@@ -2,6 +2,16 @@ import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
 
 import { Connection, MenuItem } from "../../types";
 
+export const excludeArgs =
+  (excludedArgs: string[]) =>
+  (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    args: Record<string, any> | null
+  ) =>
+    args
+      ? Object.keys(args).filter((key: string) => !excludedArgs.includes(key))
+      : false;
+
 export function getNodes<T>(connection: Connection<T>): T[] {
   return connection.edges.map(({ node }) => node);
 }

--- a/src/common/apollo/utils.ts
+++ b/src/common/apollo/utils.ts
@@ -3,11 +3,7 @@ import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
 import { Connection, MenuItem } from "../../types";
 
 export const excludeArgs =
-  (excludedArgs: string[]) =>
-  (
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    args: Record<string, any> | null
-  ) =>
+  (excludedArgs: string[]) => (args: Record<string, unknown> | null) =>
     args
       ? Object.keys(args).filter((key: string) => !excludedArgs.includes(key))
       : false;

--- a/src/domain/unifiedSearch/searchApolloClient.ts
+++ b/src/domain/unifiedSearch/searchApolloClient.ts
@@ -9,12 +9,13 @@ import { relayStylePagination } from "@apollo/client/utilities";
 
 import Config from "../../config";
 import apolloErrorLink from "../../common/apollo/apolloErrorLink";
+import { excludeArgs } from "../../common/apollo/utils";
 
 const cache: InMemoryCache = new InMemoryCache({
   typePolicies: {
     Query: {
       fields: {
-        unifiedSearch: relayStylePagination(),
+        unifiedSearch: relayStylePagination(excludeArgs(["after"])),
       },
     },
   },

--- a/src/domain/unifiedSearch/tests/UnifiedSearch.test.js
+++ b/src/domain/unifiedSearch/tests/UnifiedSearch.test.js
@@ -88,11 +88,15 @@ describe("UnifiedSearch", () => {
         q: ["B"],
       });
 
-      expect(mockRouter.replace).toHaveBeenLastCalledWith({
-        query: {
-          q: ["B"],
+      expect(mockRouter.replace).toHaveBeenLastCalledWith(
+        {
+          query: {
+            q: ["B"],
+          },
         },
-      });
+        null,
+        undefined
+      );
     });
 
     it("should allow targeting a path", () => {
@@ -103,10 +107,14 @@ describe("UnifiedSearch", () => {
 
       unifiedSearch.setFilters({}, "/search");
 
-      expect(mockRouter.replace).toHaveBeenLastCalledWith({
-        query: {},
-        pathname: "/search",
-      });
+      expect(mockRouter.replace).toHaveBeenLastCalledWith(
+        {
+          query: {},
+          pathname: "/search",
+        },
+        null,
+        undefined
+      );
     });
   });
 
@@ -166,6 +174,8 @@ describe("UnifiedSearch", () => {
               ],
             },
           },
+          null,
+          undefined,
         ]
       `);
     });

--- a/src/domain/unifiedSearch/useUnifiedSearch.ts
+++ b/src/domain/unifiedSearch/useUnifiedSearch.ts
@@ -120,6 +120,12 @@ type SpreadFilter = {
   value: string | number | boolean;
 };
 
+type TransitionOptions = {
+  shallow?: boolean;
+  locale?: string | false;
+  scroll?: boolean;
+};
+
 export class UnifiedSearch {
   router: NextRouter;
   filterConfig: FilterConfig[];
@@ -196,13 +202,21 @@ export class UnifiedSearch {
     );
   }
 
-  setFilters(search: UnifiedSearchParameters, pathname?: string) {
+  setFilters(
+    search: UnifiedSearchParameters,
+    pathname?: string,
+    options?: TransitionOptions
+  ) {
     this.queryPersister.persistQuery(search);
 
-    this.router.replace({
-      pathname,
-      query: search,
-    });
+    this.router.replace(
+      {
+        pathname,
+        query: search,
+      },
+      null,
+      options
+    );
   }
 
   getSearchParamsFromFilters(filters: SpreadFilter[]): UnifiedSearchParameters {
@@ -303,20 +317,21 @@ export default function useUnifiedSearch() {
   }
 
   const setFilters = useCallback(
-    (search: UnifiedSearchParameters, pathname?: string) => {
-      unifiedSearch.setFilters(search, pathname);
+    (...params: Parameters<typeof unifiedSearch.setFilters>) => {
+      unifiedSearch.setFilters(...params);
     },
     [unifiedSearch]
   );
 
   const modifyFilters = useCallback(
-    (search: Partial<UnifiedSearchParameters>) =>
-      unifiedSearch.modifyFilters(search),
+    (...params: Parameters<typeof unifiedSearch.modifyFilters>) =>
+      unifiedSearch.modifyFilters(...params),
     [unifiedSearch]
   );
 
   const getFiltersWithout = useCallback(
-    (key: string, value: string) => unifiedSearch.getFiltersWithout(key, value),
+    (...params: Parameters<typeof unifiedSearch.getFiltersWithout>) =>
+      unifiedSearch.getFiltersWithout(...params),
     [unifiedSearch]
   );
 

--- a/src/domain/unifiedSearch/useUnifiedSearchQuery.ts
+++ b/src/domain/unifiedSearch/useUnifiedSearchQuery.ts
@@ -64,8 +64,6 @@ export default function useUnifiedSearchQuery<TData = any>(
       ...searchParams,
       ...variables,
     },
-    fetchPolicy: "cache-and-network",
-    nextFetchPolicy: "cache-only",
     ...otherOptions,
   });
 

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -161,14 +161,20 @@ export default function Search() {
       first: BLOCK_SIZE,
       after: afterCursor,
     };
-    setFilters({
-      ...filters,
-      ...pagination,
-    });
+    setFilters(
+      {
+        ...filters,
+        ...pagination,
+      },
+      null,
+      {
+        scroll: false,
+        shallow: true,
+      }
+    );
 
     fetchMore(pagination).then(() => {
-      moreResultsAnnouncerRef.current &&
-        moreResultsAnnouncerRef.current.focus();
+      moreResultsAnnouncerRef.current?.focus();
     });
   };
 


### PR DESCRIPTION
## Description :sparkles:

When clicking load more button in the search page, it causes page to scroll to top and then right back to load more announcer. Also same request is done twice to API when fetching more event with load more button, I think it has something to do with `router.replace` and useQuerys fetchPolicy settings. To fix this issue, I added possibility to add `TransitionOptions` to setFilters function. Also unifiedSearchQuery wasn't using variables for caching because of `relayStylePagination`. I think we can get better cahcing by using keyArgs and getting rid of non-default fetching policies.



- Added possibility to pass TransitionOptions to setFilters function
- Deleted fetch policies from useUnifiedSearchQuery apollo hook 
- Added `excludeArgs` utility to be used with `relayStylePagination`

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

Click "Näytä lisää sijainteja" button on search page and page should be scrolled to top and then back down.

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
