### PR TITLE
LIIKUNTA-183 | Fix a11yIndex calculation when loading more results

### DIFF
--- a/src/common/components/list/SearchList.tsx
+++ b/src/common/components/list/SearchList.tsx
@@ -34,8 +34,19 @@ const SearchList = forwardRef(
   ) => {
     const { t } = useTranslation("search_list");
     const resultsLeft = count ? count - items.length : 0;
-    const a11yIndex = (Math.floor(items.length / blockSize) - 1) * blockSize;
-    const loadedMoreAmount = hasNext ? blockSize : count - items.length;
+
+    const getLoadedMoreAmount = () => {
+      const remainder = items.length % blockSize;
+      if (hasNext || remainder === 0) {
+        return blockSize;
+      }
+      return remainder;
+    };
+
+    const a11yIndex =
+      items.length % blockSize === 0
+        ? (Math.floor(items.length / blockSize) - 1) * blockSize
+        : items.length - getLoadedMoreAmount();
 
     if (count === 0) {
       return (
@@ -77,7 +88,7 @@ const SearchList = forwardRef(
                   aria-label={
                     loading
                       ? t("is_loading_more")
-                      : `${loadedMoreAmount} ${t("n_more_locations")}`
+                      : `${getLoadedMoreAmount()} ${t("n_more_locations")}`
                   }
                 />
               )}
@@ -103,5 +114,7 @@ const SearchList = forwardRef(
 );
 
 SearchList.displayName = "SearchList";
+
+function getLoadedMoreAmount() {}
 
 export default SearchList;

--- a/src/common/components/list/SearchList.tsx
+++ b/src/common/components/list/SearchList.tsx
@@ -115,6 +115,4 @@ const SearchList = forwardRef(
 
 SearchList.displayName = "SearchList";
 
-function getLoadedMoreAmount() {}
-
 export default SearchList;


### PR DESCRIPTION
## Description :sparkles:

More result announcer wasn't focused to correct place when loading less than 10 (block size) more venues. Also `loadedMoreAmount` was incorrect (0) when loading less than 10 results.

## Issues :bug:

### Closes :no_good_woman:

**[LIIKUNTA-183](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-183):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:



## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
