### PR TITLE
Removed the HDS utility row from footer

### DIFF
--- a/public/locales/en/footer.json
+++ b/public/locales/en/footer.json
@@ -1,6 +1,4 @@
 {
-  "back_to_top_label": "EN: Takaisin alkuun",
-  "give_feedback": "EN: Anna palautetta",
   "copyright_text": "EN: Kaikki oikeudet pidätetään",
   "about_us": "EN: Tietoa palvelusta",
   "accessibility_statement": "EN: Saavutettavuusseloste",

--- a/public/locales/fi/footer.json
+++ b/public/locales/fi/footer.json
@@ -1,6 +1,4 @@
 {
-  "back_to_top_label": "Takaisin alkuun",
-  "give_feedback": "Anna palautetta",
   "copyright_text": "Kaikki oikeudet pidätetään",
   "about_us": "Tietoa palvelusta",
   "accessibility_statement": "Saavutettavuusseloste",

--- a/public/locales/sv/footer.json
+++ b/public/locales/sv/footer.json
@@ -1,6 +1,4 @@
 {
-  "back_to_top_label": "SV: Takaisin alkuun",
-  "give_feedback": "SV: Anna palautetta",
   "copyright_text": "SV: Kaikki oikeudet pidätetään",
   "about_us": "SV: Tietoa palvelusta",
   "accessibility_statement": "SV: Saavutettavuusseloste",

--- a/src/common/components/footer/Footer.tsx
+++ b/src/common/components/footer/Footer.tsx
@@ -37,7 +37,7 @@ function Footer({ navigationItems }: Props) {
       className={styles.footer}
       logoLanguage={logoLanguage}
     >
-      <HDSFooter.Navigation>
+      <HDSFooter.Navigation variant="minimal">
         {navigationItems.map((navigationItem) => (
           <HDSFooter.Item
             key={navigationItem.id}
@@ -47,18 +47,17 @@ function Footer({ navigationItems }: Props) {
             href={navigationItem.url}
           />
         ))}
-      </HDSFooter.Navigation>
-      <HDSFooter.Base
-        copyrightHolder={t("copyright_holder")}
-        copyrightText={t("copyright_text")}
-      >
         <HDSFooter.Item href="/about" label={t("about_us")} as={Link} />
         <HDSFooter.Item
           href="/accessibility"
           label={t("accessibility_statement")}
           as={Link}
         />
-      </HDSFooter.Base>
+      </HDSFooter.Navigation>
+      <HDSFooter.Base
+        copyrightHolder={t("copyright_holder")}
+        copyrightText={t("copyright_text")}
+      ></HDSFooter.Base>
     </HDSFooter>
   );
 }

--- a/src/common/components/footer/Footer.tsx
+++ b/src/common/components/footer/Footer.tsx
@@ -48,13 +48,6 @@ function Footer({ navigationItems }: Props) {
           />
         ))}
       </HDSFooter.Navigation>
-      <HDSFooter.Utilities backToTopLabel={t("back_to_top_label")}>
-        <HDSFooter.Item
-          className={styles.FooterUtilities}
-          href="#"
-          label={t("give_feedback")}
-        />
-      </HDSFooter.Utilities>
       <HDSFooter.Base
         copyrightHolder={t("copyright_holder")}
         copyrightText={t("copyright_text")}


### PR DESCRIPTION
Removed the 2nd line from footer, since we don’t have the feedback feature yet (so the link does not do anything) and “backToTopLabel“ -feature is hard-coded to be in Footer-utilities by HDS. The middle row does not have any tests either. The second row just looked empty and funny as is also described in the Jira ticket.

LIIKUNTA-193

HDS Footer specs: https://hds.hel.fi/components/footer#default

![image](https://user-images.githubusercontent.com/389204/136210731-37517f73-bb77-4c9a-9fa0-848757c4c60e.png)


NOTE: This PR is into https://github.com/City-of-Helsinki/liikunta-helsinki/tree/LIIKUNTA-182-fix-koros, since it has fixes to koros.
