### PR TITLE
LIIKUNTA-199 | Use unified search type for ontology tree id

### DIFF
--- a/src/domain/unifiedSearch/useUnifiedSearch.ts
+++ b/src/domain/unifiedSearch/useUnifiedSearch.ts
@@ -161,7 +161,7 @@ export class UnifiedSearch {
         storeBehaviour: "list",
         key: "administrativeDivisionIds",
       },
-      { type: "number", storeBehaviour: "list", key: "ontologyTreeIds" },
+      { type: "string", storeBehaviour: "list", key: "ontologyTreeIds" },
       { type: "string", storeBehaviour: "list", key: "ontologyWordIds" },
       { type: "boolean", key: "isOpenNow" },
       { type: "date", key: "openAt" },


### PR DESCRIPTION
At some point the inference of the `ontologyTreeId` parameter was changed so that it returned a number type.

This broke compatibility with US ontology tree ids. Unified search returns a `string` type ID and TPREK returns a `number` type. We had by mistake expected `number` type from a Unified Search result.

Because this part of the code deals with Unified Search, it's better to use the type that's used within US. By changing the type we also end up fixing a number === string match that failed and resulted in a missing label.