### PR TITLE
LIIKUNTA-195 | On search results refresh, show first page instead of last

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,4 +25,7 @@ module.exports = {
   images: {
     domains: ["liikunta.content.api.hel.fi"],
   },
+  experimental: {
+    scrollRestoration: true,
+  },
 };

--- a/src/common/components/dateTimePicker/DateTimePicker.tsx
+++ b/src/common/components/dateTimePicker/DateTimePicker.tsx
@@ -261,9 +261,15 @@ export default function DateTimePicker({
           aria-hidden="true"
           className={styles.dropdownButtonIcon}
         />
-        <span className={styles.dropdownButtonTextContent}>
-          {value ? formatIntoDateTime(value) : label}
-        </span>
+        {value ? (
+          <span className={styles.dropdownButtonTextContentValue}>
+            {formatIntoDateTime(value)}
+          </span>
+        ) : (
+          <span className={styles.dropdownButtonTextContentPlaceholder}>
+            {label}
+          </span>
+        )}
         <IconAngleDown
           aria-hidden="true"
           className={styles.dropdownButtonIcon}

--- a/src/common/components/dateTimePicker/dateTimePicker.module.scss
+++ b/src/common/components/dateTimePicker/dateTimePicker.module.scss
@@ -22,6 +22,8 @@
     align-items: center;
     width: 100%;
 
+    font-size: $fontsize-body-l;
+
     border: 2px solid transparent;
     background: $color-white;
     outline: none;

--- a/src/common/components/dateTimePicker/dateTimePicker.module.scss
+++ b/src/common/components/dateTimePicker/dateTimePicker.module.scss
@@ -22,8 +22,6 @@
     align-items: center;
     width: 100%;
 
-    font-size: $fontsize-body-l;
-
     border: 2px solid transparent;
     background: $color-white;
     outline: none;
@@ -36,9 +34,15 @@
       flex-basis: calc(3rem + 4px); // Icon width in HDS input controls
     }
 
-    &TextContent {
-      text-align: start;
+    &TextContentValue,
+    &TextContentPlaceholder {
       flex-grow: 1;
+
+      font-size: $fontsize-body-l;
+      text-align: start;
+    }
+    &TextContentPlaceholder {
+      color: $color-black-60;
     }
   }
 

--- a/src/common/components/keyword/Keyword.tsx
+++ b/src/common/components/keyword/Keyword.tsx
@@ -16,6 +16,7 @@ type Props = {
     className?: string;
   }>;
   "aria-label"?: string;
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
 };
 
 const Keyword = ({

--- a/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -17,6 +17,7 @@ import searchApolloClient from "../../../domain/unifiedSearch/searchApolloClient
 import { getUnifiedSearchLanguage } from "../../../common/apollo/utils";
 import getTranslation from "../../../common/utils/getTranslation";
 import { formatIntoDateTime } from "../../../common/utils/time/format";
+import queryPersister from "../../../common/utils/queryPersister";
 import useIntermediaryState from "../../../common/hooks/useIntermediaryState";
 import Text from "../../../common/components/text/Text";
 import SuggestionInput, {
@@ -266,10 +267,18 @@ function SearchPageSearchForm({
                 href={{
                   query: getQueryWithout(key, value),
                 }}
+                onClick={() => {
+                  queryPersister.persistQuery(getQueryWithout(key, value));
+                }}
               />
             ))}
             <Link href={searchRoute}>
-              <a className={styles.clearSearchParameters}>
+              <a
+                className={styles.clearSearchParameters}
+                onClick={() => {
+                  queryPersister.persistQuery({});
+                }}
+              >
                 {t("clear_filters")}
               </a>
             </Link>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -165,17 +165,10 @@ export default function Search() {
       first: BLOCK_SIZE,
       after: afterCursor,
     };
-    setFilters(
-      {
-        ...filters,
-        ...pagination,
-      },
-      null,
-      {
-        scroll: false,
-        shallow: true,
-      }
-    );
+    setFilters(filters, null, {
+      scroll: false,
+      shallow: true,
+    });
 
     fetchMore(pagination).then(() => {
       moreResultsAnnouncerRef.current?.focus();


### PR DESCRIPTION
The main change here is that we are dropping pagination parameters from the search and hence not persisting them over page refreshes. This results in behaviour where on page refreshes, instead of the last page, the first page is shown.

This PR also contains a few other very minor fixes:

- Adjusts font-size and color for DateTimePicker's button component so that it's inline with HDS
- Adds experimental `scrollRestoration: true` config to NextJS which should fix unrestored scroll state on `history.back`. Mainly affected us on the search view.
- Integrates the filter list with query persister, fixing issue where queries modified through the filter list would not be persisted