### PR TITLE
LIIKUNTA-99 | Focus form when opening it in map view

### DIFF
--- a/src/domain/search/searchHeader/SearchHeader.tsx
+++ b/src/domain/search/searchHeader/SearchHeader.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { IconCross, Button, IconSearch, IconMenuHamburger } from "hds-react";
 import { useTranslation } from "next-i18next";
 
@@ -20,11 +20,12 @@ type Props = {
 function SearchHeader({ showMode, count, switchShowMode, searchForm }: Props) {
   const { t } = useTranslation("search_header");
   const [collapsed, setCollapsed] = useState<boolean>(true);
+  const formWrapper = useRef<HTMLDivElement>();
 
   return (
     <>
       {showMode === ShowMode.MAP && (
-        <div className={styles.searchHeader}>
+        <div ref={formWrapper} className={styles.searchHeader}>
           {!collapsed && (
             <div className={styles.searchMenu}>
               {searchForm}
@@ -60,7 +61,29 @@ function SearchHeader({ showMode, count, switchShowMode, searchForm }: Props) {
                   variant="secondary"
                   theme="black"
                   iconLeft={<IconSearch />}
-                  onClick={() => setCollapsed(false)}
+                  onClick={() => {
+                    setCollapsed(false);
+
+                    // This button comes after the actual form in the DOM order.
+                    // It's rendered out of the UI as the state changes to
+                    // !collapsed, but the focus is re-applied to elements that
+                    // come after the form elements.
+                    //
+                    // This makes the UX cumbersome when using a keyboard or a
+                    // screen reader. In order to improve the UX, we are moving
+                    // the focus to the beginning of the form when the user
+                    // opens it.
+                    //
+                    // Wait for form to be rendered into the DOM
+                    setTimeout(() => {
+                      const firstFormInput = formWrapper.current?.querySelector(
+                        "form input"
+                      ) as HTMLInputElement | null | undefined;
+
+                      // And focus the first input on it
+                      firstFormInput?.focus();
+                    }, 0);
+                  }}
                 >
                   {t("show_search_parameters")}
                 </Button>


### PR DESCRIPTION
After this change, opening the search form in the map view will move the user's focus to the beginning of the search form.

Previously user focus would remain after the form in DOM order. Hence it could be easy to miss the form as a screen reader user. After opening the form and continuing forward, the user would have ended up on the map instead of the form.

I tested this approach with a screen reader and it was relatively OK, but the focus switch is a bit jarring. For that reason I changed the label of the button on screen readers from "Show search" to "Go to search form". I would expect that this makes the change of focus less unexpected.

After doing the changes, this approach definitely feels quite brittle. I feel like perhaps we should have adjusted the design or refactored the component itself more, so that buttons change labels instead of being re-created for instance. That could have allowed, maybe, us to use flex order to accomplish an UX where we don't shift focus, but ensure that the form is after the button in focus order. This would break a accessibility standard, that the visible order is the same ad the DOM order, but this is an instance where that could perhaps be warranted. Anyway, I went with this approach because I wasn't sure and didn't want to spend any more time on this.