### PR TITLE
LIIKUNTA-210 | Fix broken filter keywords

### DIFF
--- a/src/domain/i18n/router/Link.tsx
+++ b/src/domain/i18n/router/Link.tsx
@@ -7,31 +7,14 @@ import useRouter from "./useRouter";
 import { getI18nPath, stringifyUrlObject } from "./utils";
 import { Locale } from "../../../config";
 
-function getI18nHref(
-  href: string | UrlObject,
-  locale: Locale,
-  defaultPathname: string
-): string | UrlObject | null {
-  if (typeof href === "string") {
-    // If the href is a string we are not able to confidently unpack the href
-    // into routes and params.
-    return null;
-  }
-
+function getI18nHref(href: UrlObject, locale: Locale, defaultPathname: string) {
   return {
     ...href,
     pathname: getI18nPath(href.pathname, locale) ?? defaultPathname,
   };
 }
 
-function getHrefThatAvoidsEscaping(
-  href: string | UrlObject | null
-): string | null {
-  if (!href || typeof href === "string") {
-    // If the href is a string it won't be unescaped
-    return null;
-  }
-
+function getHrefThatAvoidsEscaping(href: UrlObject | null) {
   return stringifyUrlObject(href);
 }
 
@@ -42,6 +25,12 @@ type Props = React.PropsWithChildren<Omit<LinkProps, "locale">> & {
 
 export default function Link({ href, escape, ...delegated }: Props) {
   const router = useRouter();
+
+  // Use string hrefs as is
+  if (typeof href === "string") {
+    return <NextLink {...delegated} href={href} />;
+  }
+
   const locale = delegated.locale || router.locale;
   const i18nHref = getI18nHref(href, locale, router.pathname) ?? href;
   const enhancedHref = escape

--- a/src/domain/i18n/router/Link.tsx
+++ b/src/domain/i18n/router/Link.tsx
@@ -7,17 +7,6 @@ import useRouter from "./useRouter";
 import { getI18nPath, stringifyUrlObject } from "./utils";
 import { Locale } from "../../../config";
 
-function getI18nHref(href: UrlObject, locale: Locale, defaultPathname: string) {
-  return {
-    ...href,
-    pathname: getI18nPath(href.pathname, locale) ?? defaultPathname,
-  };
-}
-
-function getHrefThatAvoidsEscaping(href: UrlObject | null) {
-  return stringifyUrlObject(href);
-}
-
 type Props = React.PropsWithChildren<Omit<LinkProps, "locale">> & {
   escape?: boolean;
   locale?: Locale | false;
@@ -32,10 +21,13 @@ export default function Link({ href, escape, ...delegated }: Props) {
   }
 
   const locale = delegated.locale || router.locale;
-  const i18nHref = getI18nHref(href, locale, router.pathname) ?? href;
+  const i18nHref = {
+    ...href,
+    pathname: getI18nPath(href.pathname, locale) ?? router.pathname,
+  };
   const enhancedHref = escape
     ? i18nHref
-    : getHrefThatAvoidsEscaping(i18nHref) ?? i18nHref;
+    : stringifyUrlObject(i18nHref) ?? i18nHref;
 
   return <NextLink {...delegated} href={enhancedHref} />;
 }

--- a/src/domain/i18n/router/Link.tsx
+++ b/src/domain/i18n/router/Link.tsx
@@ -9,7 +9,8 @@ import { Locale } from "../../../config";
 
 function getI18nHref(
   href: string | UrlObject,
-  locale: Locale
+  locale: Locale,
+  defaultPathname: string
 ): string | UrlObject | null {
   if (typeof href === "string") {
     // If the href is a string we are not able to confidently unpack the href
@@ -19,7 +20,7 @@ function getI18nHref(
 
   return {
     ...href,
-    pathname: getI18nPath(href.pathname, locale),
+    pathname: getI18nPath(href.pathname, locale) ?? defaultPathname,
   };
 }
 
@@ -42,7 +43,7 @@ type Props = React.PropsWithChildren<Omit<LinkProps, "locale">> & {
 export default function Link({ href, escape, ...delegated }: Props) {
   const router = useRouter();
   const locale = delegated.locale || router.locale;
-  const i18nHref = getI18nHref(href, locale) ?? href;
+  const i18nHref = getI18nHref(href, locale, router.pathname) ?? href;
   const enhancedHref = escape
     ? i18nHref
     : getHrefThatAvoidsEscaping(i18nHref) ?? i18nHref;

--- a/src/domain/i18n/router/__test__/Link.test.js
+++ b/src/domain/i18n/router/__test__/Link.test.js
@@ -1,0 +1,30 @@
+import { render, screen } from "../../../../tests/utils";
+import Link from "../Link";
+
+describe("<Link />", () => {
+  it("should retain current pathname if none is provided in href object", () => {
+    const label = "Test Link";
+
+    render(
+      <Link
+        href={{
+          query: {
+            isOpenNow: true,
+          },
+        }}
+      >
+        {label}
+      </Link>,
+      undefined,
+      {
+        pathname: "/search",
+      }
+    );
+
+    expect(
+      screen.getByRole("link", {
+        name: label,
+      }).href
+    ).toMatchInlineSnapshot(`"http://localhost/search?isOpenNow=true"`);
+  });
+});

--- a/src/domain/i18n/router/__test__/utils.test.js
+++ b/src/domain/i18n/router/__test__/utils.test.js
@@ -1,0 +1,34 @@
+import { stringifyUrlObject } from "../utils";
+
+describe("i18n router utils", () => {
+  describe("stringifyUrlObject", () => {
+    it("should correctly stringify url object with search", () => {
+      expect(
+        stringifyUrlObject({
+          pathname: "/venue/[id]/map",
+          search: "?isOpenNow=true&q=Swimming%20Pool",
+          query: {
+            id: "tprek:123",
+          },
+        })
+      ).toMatchInlineSnapshot(
+        `"/venue/tprek:123/map?isOpenNow=true&q=Swimming%20Pool"`
+      );
+    });
+
+    it("should correctly stringify url object with query", () => {
+      expect(
+        stringifyUrlObject({
+          pathname: "/venue/[id]/map",
+          query: {
+            id: "tprek:123",
+            isOpenNow: true,
+            q: "Swimming Pool",
+          },
+        })
+      ).toMatchInlineSnapshot(
+        `"/venue/tprek:123/map?isOpenNow=true&q=Swimming%20Pool"`
+      );
+    });
+  });
+});

--- a/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -255,23 +255,27 @@ function SearchPageSearchForm({
         </div>
         {filterList.length > 0 && (
           <div className={styles.searchAsFilters}>
-            {filterList.map(({ key, value }) => (
-              <Keyword
-                key={`${key}-${value}`}
-                color="black"
-                icon={IconCross}
-                aria-label={`${t(
-                  "remove_filter_aria_label"
-                )}: ${getSearchParameterLabel(key, value)}`}
-                keyword={getSearchParameterLabel(key, value)}
-                href={{
-                  query: getQueryWithout(key, value),
-                }}
-                onClick={() => {
-                  queryPersister.persistQuery(getQueryWithout(key, value));
-                }}
-              />
-            ))}
+            {filterList.map(({ key, value }) => {
+              const queryWithout = getQueryWithout(key, value);
+
+              return (
+                <Keyword
+                  key={`${key}-${value}`}
+                  color="black"
+                  icon={IconCross}
+                  aria-label={`${t(
+                    "remove_filter_aria_label"
+                  )}: ${getSearchParameterLabel(key, value)}`}
+                  keyword={getSearchParameterLabel(key, value)}
+                  href={{
+                    query: queryWithout,
+                  }}
+                  onClick={() => {
+                    queryPersister.persistQuery(queryWithout);
+                  }}
+                />
+              );
+            })}
             <Link href={searchRoute}>
               <a
                 className={styles.clearSearchParameters}


### PR DESCRIPTION
The issues were caused by behaviour that differs from the default behaviour of NextJS and were brought about with the change where we begun to use our custom stringification routine by default. Unfortunately it didn't have support for `query` as a way of providing search parameters, nor did it retain the current `pathname` if a new one was not provided. The stringification routine Next uses is relatively complex and this regression highlights the difficulty of maintaining logic that attempts to mimic that. We should look to replace the current `escape` with a better approach, but I didn't spend time on that now.

<img width="619" alt="Screenshot 2021-10-19 at 16 28 08" src="https://user-images.githubusercontent.com/9090689/137919355-241a340f-68f9-4e51-9e46-da967aee5fa7.png">
