### PR TITLE
LIIKUNTA 200, 201, 202, 203 | Fix accessibility issues discovered during initial accessibility testing

### DIFF
--- a/public/locales/en/card.json
+++ b/public/locales/en/card.json
@@ -1,3 +1,4 @@
 {
-  "go_to_content": "Jump to content"
+  "go_to_content": "Jump to content",
+  "a11y_default_keywords_group_name": "EN: Asiasanat"
 }

--- a/public/locales/en/venue_page.json
+++ b/public/locales/en/venue_page.json
@@ -18,5 +18,6 @@
   "map_box.title": "Location",
   "map_box.accessibility_sentences": "Accessibility",
   "other_sports_section.title": "EN: Muuta samankaltaista liikuntaa",
-  "back_to_venue_page_aria_label": "EN: Takaisin liikuntapaikkasivulle"
+  "back_to_venue_page_aria_label": "EN: Takaisin liikuntapaikkasivulle",
+  "a11y_keywords_group_name": "EN: Asiasanat"
 }

--- a/public/locales/fi/card.json
+++ b/public/locales/fi/card.json
@@ -1,3 +1,4 @@
 {
-  "go_to_content": "Siirry sisältöön"
+  "go_to_content": "Siirry sisältöön",
+  "a11y_default_keywords_group_name": "Asiasanat"
 }

--- a/public/locales/fi/venue_page.json
+++ b/public/locales/fi/venue_page.json
@@ -18,5 +18,6 @@
   "map_box.title": "Sijainti",
   "map_box.accessibility_sentences": "Esteettömyystiedot",
   "other_sports_section.title": "Muuta samankaltaista liikuntaa",
-  "back_to_venue_page_aria_label": "Takaisin liikuntapaikkasivulle"
+  "back_to_venue_page_aria_label": "Takaisin liikuntapaikkasivulle",
+  "a11y_keywords_group_name": "Asiasanat"
 }

--- a/public/locales/sv/card.json
+++ b/public/locales/sv/card.json
@@ -1,3 +1,4 @@
 {
-  "go_to_content": "Gå till innehållet"
+  "go_to_content": "Gå till innehållet",
+  "a11y_default_keywords_group_name": "SV: Asiasanat"
 }

--- a/public/locales/sv/venue_page.json
+++ b/public/locales/sv/venue_page.json
@@ -18,5 +18,6 @@
   "map_box.title": "Läge",
   "map_box.accessibility_sentences": "Information om tillgängligheten",
   "other_sports_section.title": "SV: Muuta samankaltaista liikuntaa",
-  "back_to_venue_page_aria_label": "SV: Takaisin liikuntapaikkasivulle"
+  "back_to_venue_page_aria_label": "SV: Takaisin liikuntapaikkasivulle",
+  "a11y_keywords_group_name": "SV: Asiasanat"
 }

--- a/src/common/components/card/Card.tsx
+++ b/src/common/components/card/Card.tsx
@@ -161,9 +161,19 @@ function CardCtaButton({ className, children }: CardCtaButtonProps) {
 type CardKeywordsProps = {
   keywords: KeywordType[];
   className?: string;
+  a11yKeywordsGroupName?: string;
 };
 
-function CardKeywords({ keywords, className }: CardKeywordsProps) {
+function CardKeywords({
+  keywords,
+  className,
+  a11yKeywordsGroupName: _a11yKeywordsGroupName,
+}: CardKeywordsProps) {
+  const { t } = useTranslation("card");
+
+  const a11yKeywordsGroupName =
+    _a11yKeywordsGroupName ?? t("a11y_default_keywords_group_name");
+
   // stop propagation so link click is not simulated in Card component
   const handleKeywordMouseUp = (
     e: React.MouseEvent<HTMLLIElement, MouseEvent>
@@ -172,7 +182,10 @@ function CardKeywords({ keywords, className }: CardKeywordsProps) {
   };
 
   return (
-    <ul className={classNames(styles.keywords, className)}>
+    <ul
+      className={classNames(styles.keywords, className)}
+      aria-label={a11yKeywordsGroupName}
+    >
       {keywords
         .filter(({ label }) => label !== null)
         .map(({ label, href, isHighlighted }) => {

--- a/src/common/components/card/Card.tsx
+++ b/src/common/components/card/Card.tsx
@@ -134,7 +134,7 @@ function CardCta({ className }: CardCtaProps) {
       aria-label={t("go_to_content")}
       id={`cta:${id}`}
     >
-      <IconArrowRight />
+      <IconArrowRight aria-hidden="true" />
     </span>
   );
 }

--- a/src/common/components/dateTimePicker/DateTimePicker.tsx
+++ b/src/common/components/dateTimePicker/DateTimePicker.tsx
@@ -306,7 +306,7 @@ export default function DateTimePicker({
           />
           <div className={styles.buttonRow}>
             <Button
-              iconLeft={<IconCheck />}
+              iconLeft={<IconCheck aria-hidden="true" />}
               variant="secondary"
               onClick={handleSelectDateClick}
               size="small"
@@ -315,7 +315,7 @@ export default function DateTimePicker({
               {t("select")}
             </Button>
             <Button
-              iconLeft={<IconCross />}
+              iconLeft={<IconCross aria-hidden="true" />}
               variant="supplementary"
               onClick={handleCloseMenuButtonClick}
               size="small"

--- a/src/common/components/infoBlock/InfoBlock.tsx
+++ b/src/common/components/infoBlock/InfoBlock.tsx
@@ -171,11 +171,14 @@ function InfoBlock({ icon, name, contents, target = "body" }: Props) {
     return null;
   }
 
+  // If this logic becomes any more complex, create different flavoured
+  // variants.
   const textVariant = target === "card" ? "body" : "h5";
+  const textAs = target === "card" ? "h3" : "h4";
 
   return (
     <div className={classNames(styles.infoBlock, styles[target])}>
-      <Text as="h4" variant={textVariant} className={styles.name}>
+      <Text as={textAs} variant={textVariant} className={styles.name}>
         {icon} {name}
       </Text>
       <ul className={styles.content}>

--- a/src/common/components/infoBlock/InfoBlock.tsx
+++ b/src/common/components/infoBlock/InfoBlock.tsx
@@ -144,9 +144,16 @@ type Props = {
   name: string;
   contents: InfoBlockContent[];
   target?: "body" | "card";
+  headingLevel?: "h2" | "h3" | "h4";
 };
 
-function InfoBlock({ icon, name, contents, target = "body" }: Props) {
+function InfoBlock({
+  icon,
+  name,
+  contents,
+  target = "body",
+  headingLevel = "h4",
+}: Props) {
   const contentWithoutEmpty = contents.filter((item) => {
     if (typeof item === "string") {
       return Boolean(item);
@@ -171,14 +178,11 @@ function InfoBlock({ icon, name, contents, target = "body" }: Props) {
     return null;
   }
 
-  // If this logic becomes any more complex, create different flavoured
-  // variants.
   const textVariant = target === "card" ? "body" : "h5";
-  const textAs = target === "card" ? "h3" : "h4";
 
   return (
     <div className={classNames(styles.infoBlock, styles[target])}>
-      <Text as={textAs} variant={textVariant} className={styles.name}>
+      <Text as={headingLevel} variant={textVariant} className={styles.name}>
         {icon} {name}
       </Text>
       <ul className={styles.content}>

--- a/src/common/components/infoBlock/InfoBlock.tsx
+++ b/src/common/components/infoBlock/InfoBlock.tsx
@@ -76,7 +76,7 @@ function InfoBlockLink({
     <Link href={href}>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <a className={styles.link} onMouseUp={(e) => e.stopPropagation()}>
-        <span>{label}</span> <IconAngleRight />
+        <span>{label}</span> <IconAngleRight aria-hidden="true" />
       </a>
     </Link>
   );

--- a/src/common/components/infoBlock/infoBlock.module.scss
+++ b/src/common/components/infoBlock/infoBlock.module.scss
@@ -51,7 +51,9 @@
 
   .body & {
     font-size: $fontsize-body-l;
-    color: $color-copper-dark;
+    // Custom color value. Custom value was created so that enough contrast
+    // could be generated between the text and the background.
+    color: #008667;
   }
 
   .card & {

--- a/src/common/components/infoTemplate/InfoTemplate.tsx
+++ b/src/common/components/infoTemplate/InfoTemplate.tsx
@@ -17,7 +17,7 @@ const InfoTemplate = ({ title, description, icon: Icon }: Props) => {
       <div className={styles.infoTemplate}>
         {Icon && (
           <span className={styles.infoTemplateIcon}>
-            <Icon size="xl" />
+            <Icon size="xl" aria-hidden="true" />
           </span>
         )}
         <Text variant="h2">{title}</Text>

--- a/src/common/components/keyword/Keyword.tsx
+++ b/src/common/components/keyword/Keyword.tsx
@@ -39,7 +39,7 @@ const Keyword = ({
           [styles.withIcon]: Icon,
         })}
       >
-        {Icon && <Icon className={styles.icon} />}
+        {Icon && <Icon className={styles.icon} aria-hidden="true" />}
         {keyword}
       </a>
     </Link>

--- a/src/common/components/link/CategoryLink.tsx
+++ b/src/common/components/link/CategoryLink.tsx
@@ -22,7 +22,7 @@ const CategoryLink = ({ className, icon, href, label }: Props) => {
         <a>
           {icon}
           <span>{label}</span>
-          <IconAngleRight aria-hidden />
+          <IconAngleRight aria-hidden="true" />
         </a>
       </Link>
     </div>

--- a/src/common/components/link/SecondaryLink.tsx
+++ b/src/common/components/link/SecondaryLink.tsx
@@ -14,7 +14,7 @@ const SecondaryLink = React.forwardRef<HTMLAnchorElement, Props>(
         {...props}
         className={classNames(styles.secondaryLink, className)}
       >
-        {children} <IconAngleRight size="s" />
+        {children} <IconAngleRight size="s" aria-hidden="true" />
       </a>
     );
   }

--- a/src/common/components/list/SearchList.tsx
+++ b/src/common/components/list/SearchList.tsx
@@ -127,7 +127,7 @@ const SearchList = forwardRef(
           <div className={styles.row}>
             <Button
               onClick={switchShowMode}
-              iconLeft={<IconMap />}
+              iconLeft={<IconMap aria-hidden="true" />}
               className={styles.showOnMap}
             >
               {t("show_on_map")}

--- a/src/common/components/mapBox/MapBox.tsx
+++ b/src/common/components/mapBox/MapBox.tsx
@@ -31,7 +31,7 @@ function MapBox({
     <div className={styles.wrapper}>
       <div className={styles.title}>
         <div className={styles.titleText}>
-          <IconLocation aria-hidden />
+          <IconLocation aria-hidden="true" />
           <Text variant="h3">{title}</Text>
         </div>
         <a

--- a/src/common/components/mapBox/mapBox.module.scss
+++ b/src/common/components/mapBox/mapBox.module.scss
@@ -49,7 +49,7 @@
   margin-top: $spacing-s;
 
   a {
-    color: $color-copper-dark;
+    color: $color-tram-dark;
   }
 
   & > *:not(:last-child) {

--- a/src/common/components/multiSelectCombobox/MultiSelectCombobox.tsx
+++ b/src/common/components/multiSelectCombobox/MultiSelectCombobox.tsx
@@ -51,7 +51,7 @@ export default function MultiSelectCombobox({
       onChange={handleOnChange}
       // The design asks for an icon, but HDS does not allow icons for the
       // multiSelect variant of an combobox.
-      // icon={<IconLocation />}
+      // icon={<IconLocation aria-hidden="true" />}
       // The options list will break without this option because the data has
       // duplicate labels.
       virtualized

--- a/src/common/components/shareLinks/FacebookShareLink.tsx
+++ b/src/common/components/shareLinks/FacebookShareLink.tsx
@@ -18,7 +18,7 @@ const FacebookShareLink = ({ sharedLink }: ShareLinkProps) => {
       queryParameters={queryParameters}
       windowName={linkLabel}
       linkLabel={linkLabel}
-      icon={<IconFacebook />}
+      icon={<IconFacebook aria-hidden="true" />}
     />
   );
 };

--- a/src/common/components/shareLinks/LinkedInShareLink.tsx
+++ b/src/common/components/shareLinks/LinkedInShareLink.tsx
@@ -18,7 +18,7 @@ const LinkedInShareLink = ({ sharedLink }: ShareLinkProps) => {
       queryParameters={queryParameters}
       windowName={linkLabel}
       linkLabel={linkLabel}
-      icon={<IconLinkedin />}
+      icon={<IconLinkedin aria-hidden="true" />}
     />
   );
 };

--- a/src/common/components/shareLinks/ShareLinks.tsx
+++ b/src/common/components/shareLinks/ShareLinks.tsx
@@ -31,7 +31,7 @@ const ShareLinks = () => {
           aria-label={t("copy.label")}
           title={t("copy.label")}
         >
-          <IconLink />
+          <IconLink aria-hidden="true" />
         </CopyButton>
       </li>
       <li>

--- a/src/common/components/shareLinks/TwitterShareLink.tsx
+++ b/src/common/components/shareLinks/TwitterShareLink.tsx
@@ -18,7 +18,7 @@ const TwitterShareLink = ({ sharedLink }: ShareLinkProps) => {
       queryParameters={queryParameters}
       windowName={linkLabel}
       linkLabel={linkLabel}
-      icon={<IconTwitter />}
+      icon={<IconTwitter aria-hidden="true" />}
     />
   );
 };

--- a/src/common/components/shareLinks/tests/__snapshots__/FacebookShareLink.test.jsx.snap
+++ b/src/common/components/shareLinks/tests/__snapshots__/FacebookShareLink.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`<FacebookShareLink /> matches snapshot 1`] = `
   type="button"
 >
   <svg
+    aria-hidden="true"
     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
     role="img"
     viewBox="0 0 24 24"

--- a/src/common/components/shareLinks/tests/__snapshots__/LinkedInShareLink.test.jsx.snap
+++ b/src/common/components/shareLinks/tests/__snapshots__/LinkedInShareLink.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`<LinkedInShareLink /> matches snapshot 1`] = `
   type="button"
 >
   <svg
+    aria-hidden="true"
     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
     role="img"
     viewBox="0 0 24 24"

--- a/src/common/components/shareLinks/tests/__snapshots__/TwitterShareLink.test.jsx.snap
+++ b/src/common/components/shareLinks/tests/__snapshots__/TwitterShareLink.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`<TwitterShareLink /> matches snapshot 1`] = `
   type="button"
 >
   <svg
+    aria-hidden="true"
     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
     role="img"
     viewBox="0 0 24 24"

--- a/src/domain/clients/tmp/mockCategories.tsx
+++ b/src/domain/clients/tmp/mockCategories.tsx
@@ -12,43 +12,43 @@ import IconTree from "../../../common/components/icons/IconTree";
 
 const mockCategories = [
   {
-    icon: <IconMovies />,
+    icon: <IconMovies aria-hidden="true" />,
     label: "Lorem",
   },
   {
-    icon: <IconMusic />,
+    icon: <IconMusic aria-hidden="true" />,
     label: "Ipsum",
   },
   {
-    icon: <IconSports />,
+    icon: <IconSports aria-hidden="true" />,
     label: "Pyöräily",
   },
   {
-    icon: <IconMuseum />,
+    icon: <IconMuseum aria-hidden="true" />,
     label: "Lorem",
   },
   {
-    icon: <IconDance />,
+    icon: <IconDance aria-hidden="true" />,
     label: "Tanssi",
   },
   {
-    icon: <IconCultureAndArts />,
+    icon: <IconCultureAndArts aria-hidden="true" />,
     label: "Uinti",
   },
   {
-    icon: <IconTree />,
+    icon: <IconTree aria-hidden="true" />,
     label: "Lenkkeily",
   },
   {
-    icon: <IconTree />,
+    icon: <IconTree aria-hidden="true" />,
     label: "Lorem",
   },
   {
-    icon: <IconTheatre />,
+    icon: <IconTheatre aria-hidden="true" />,
     label: "Ipsum",
   },
   {
-    icon: <IconFood />,
+    icon: <IconFood aria-hidden="true" />,
     label: "Dolor",
   },
 ];

--- a/src/domain/search/landingPageSearchForm/LandingPageSearchForm.tsx
+++ b/src/domain/search/landingPageSearchForm/LandingPageSearchForm.tsx
@@ -44,7 +44,7 @@ function LandingPageSearchForm() {
       </TextInput>
       <Button
         type="submit"
-        iconLeft={<IconSearch />}
+        iconLeft={<IconSearch aria-hidden="true" />}
         className={styles.hdsButtonOverrides}
       >
         {t("do_search")}

--- a/src/domain/search/searchHeader/SearchHeader.tsx
+++ b/src/domain/search/searchHeader/SearchHeader.tsx
@@ -33,7 +33,7 @@ function SearchHeader({ showMode, count, switchShowMode, searchForm }: Props) {
                 className={styles.closeSearch}
                 variant="secondary"
                 theme="black"
-                iconLeft={<IconCross />}
+                iconLeft={<IconCross aria-hidden="true" />}
                 fullWidth
                 onClick={() => setCollapsed(true)}
               >
@@ -47,7 +47,7 @@ function SearchHeader({ showMode, count, switchShowMode, searchForm }: Props) {
                 <Button
                   variant="secondary"
                   theme="black"
-                  iconLeft={<IconMenuHamburger />}
+                  iconLeft={<IconMenuHamburger aria-hidden="true" />}
                   onClick={switchShowMode}
                 >
                   {t("show_as_a_list")}
@@ -60,7 +60,7 @@ function SearchHeader({ showMode, count, switchShowMode, searchForm }: Props) {
                 <Button
                   variant="secondary"
                   theme="black"
-                  iconLeft={<IconSearch />}
+                  iconLeft={<IconSearch aria-hidden="true" />}
                   onClick={() => {
                     setCollapsed(false);
 

--- a/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -291,7 +291,7 @@ function SearchPageSearchForm({
         <Button
           type="submit"
           className={styles.submitButton}
-          iconLeft={<IconSearch />}
+          iconLeft={<IconSearch aria-hidden="true" />}
         >
           {t("do_search")}
         </Button>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -269,7 +269,7 @@ export default function Search() {
                 key="location"
                 target="card"
                 headingLevel="h3"
-                icon={<IconLocation />}
+                icon={<IconLocation aria-hidden="true" />}
                 name={
                   streetAddress
                     ? getTranslation(
@@ -291,7 +291,7 @@ export default function Search() {
                   key="openingHours"
                   target="card"
                   headingLevel="h3"
-                  icon={<IconClock />}
+                  icon={<IconClock aria-hidden="true" />}
                   name={
                     isOpenNow
                       ? t("block.opening_hours.open_now_label")

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -268,6 +268,7 @@ export default function Search() {
               <InfoBlock
                 key="location"
                 target="card"
+                headingLevel="h3"
                 icon={<IconLocation />}
                 name={
                   streetAddress
@@ -289,6 +290,7 @@ export default function Search() {
                 <InfoBlock
                   key="openingHours"
                   target="card"
+                  headingLevel="h3"
                   icon={<IconClock />}
                   name={
                     isOpenNow

--- a/src/pages/venues/[id]/index.tsx
+++ b/src/pages/venues/[id]/index.tsx
@@ -248,7 +248,7 @@ export function VenuePageContent() {
       className={styles.accessibilitySentences}
       titleClassName={styles.accessibilityTitle}
       title={t("map_box.accessibility_sentences")}
-      icon={<IconAngleDown aria-hidden className={styles.icon} />}
+      icon={<IconAngleDown aria-hidden="true" className={styles.icon} />}
       items={accessibilitySentences.map((group) => (
         <React.Fragment key={`accessibility-${group.groupName}`}>
           <Text variant="body-l" className={styles.groupName}>
@@ -262,7 +262,7 @@ export function VenuePageContent() {
   const infoLines = [
     {
       id: "address",
-      icon: <IconLocation />,
+      icon: <IconLocation aria-hidden="true" />,
       info: simplifiedAddress,
     },
   ];
@@ -338,7 +338,7 @@ export function VenuePageContent() {
             {openingHours && (
               <InfoBlock
                 headingLevel="h3"
-                icon={<IconClock />}
+                icon={<IconClock aria-hidden="true" />}
                 name={
                   isOpen
                     ? t("block.opening_hours.open_now_label")
@@ -350,7 +350,7 @@ export function VenuePageContent() {
             {temperature && (
               <InfoBlock
                 headingLevel="h3"
-                icon={<IconQuestionCircle />}
+                icon={<IconQuestionCircle aria-hidden="true" />}
                 name="Veden tiedot"
                 contents={[
                   "+22 astetta, ei sinilevää\nPäivitetty 21.7.2021 klo 12:12",
@@ -359,7 +359,7 @@ export function VenuePageContent() {
             )}
             <InfoBlock
               headingLevel="h3"
-              icon={<IconLocation />}
+              icon={<IconLocation aria-hidden="true" />}
               name={t("block.location.label")}
               contents={[
                 <InfoBlock.List
@@ -375,7 +375,7 @@ export function VenuePageContent() {
             />
             <InfoBlock
               headingLevel="h3"
-              icon={<IconInfoCircle />}
+              icon={<IconInfoCircle aria-hidden="true" />}
               name={t("block.other_information.label")}
               contents={[
                 <InfoBlock.List
@@ -404,7 +404,7 @@ export function VenuePageContent() {
             />
             <InfoBlock
               headingLevel="h3"
-              icon={<IconMap />}
+              icon={<IconMap aria-hidden="true" />}
               name={t("block.route.label")}
               contents={[
                 <InfoBlock.List key="directions-hsl" items={[hslInfoLink]} />,
@@ -417,7 +417,7 @@ export function VenuePageContent() {
             {organizer && (
               <InfoBlock
                 headingLevel="h3"
-                icon={<IconLocation />}
+                icon={<IconLocation aria-hidden="true" />}
                 name="Liikunnan tiedot"
                 contents={[
                   <InfoBlock.List

--- a/src/pages/venues/[id]/index.tsx
+++ b/src/pages/venues/[id]/index.tsx
@@ -337,6 +337,7 @@ export function VenuePageContent() {
           <aside className={styles.aside}>
             {openingHours && (
               <InfoBlock
+                headingLevel="h3"
                 icon={<IconClock />}
                 name={
                   isOpen
@@ -348,6 +349,7 @@ export function VenuePageContent() {
             )}
             {temperature && (
               <InfoBlock
+                headingLevel="h3"
                 icon={<IconQuestionCircle />}
                 name="Veden tiedot"
                 contents={[
@@ -356,6 +358,7 @@ export function VenuePageContent() {
               />
             )}
             <InfoBlock
+              headingLevel="h3"
               icon={<IconLocation />}
               name={t("block.location.label")}
               contents={[
@@ -371,6 +374,7 @@ export function VenuePageContent() {
               ]}
             />
             <InfoBlock
+              headingLevel="h3"
               icon={<IconInfoCircle />}
               name={t("block.other_information.label")}
               contents={[
@@ -399,6 +403,7 @@ export function VenuePageContent() {
               ]}
             />
             <InfoBlock
+              headingLevel="h3"
               icon={<IconMap />}
               name={t("block.route.label")}
               contents={[
@@ -411,6 +416,7 @@ export function VenuePageContent() {
             />
             {organizer && (
               <InfoBlock
+                headingLevel="h3"
                 icon={<IconLocation />}
                 name="Liikunnan tiedot"
                 contents={[

--- a/src/pages/venues/[id]/index.tsx
+++ b/src/pages/venues/[id]/index.tsx
@@ -304,7 +304,10 @@ export function VenuePageContent() {
           </div>
           <div className={styles.content}>
             {keywords && (
-              <ul className={styles.keywords}>
+              <ul
+                className={styles.keywords}
+                aria-label={t("a11y_keywords_group_name")}
+              >
                 {keywords.map((keyword) => (
                   <li key={keyword.id}>
                     <Keyword

--- a/src/pages/venues/[id]/venue.module.scss
+++ b/src/pages/venues/[id]/venue.module.scss
@@ -207,7 +207,7 @@
   .accessibilityTitle {
     display: flex;
     align-items: center;
-    color: $color-copper-dark;
+    color: $color-tram-dark;
     font-weight: 700;
     font-size: 1.2rem;
 


### PR DESCRIPTION
## Description

- Adds `aria-label` for the keyword list that each search result has in the search view
- Adds `aria-label` for the keyword list that's shown on the venue page
- Fixes incorrect heading structure on the search results page
- Fixes incorrect heading structure on the venue details page
- Fixes insufficient contrast issue on the venue details page
- Fixes decorative icons that were not hidden from screen readers

## Issues

### Closes

**[LIIKUNTA-200](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-200)**
**[LIIKUNTA-201](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-201)**
**[LIIKUNTA-202](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-202)**
**[LIIKUNTA-203](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-203)**

### Related

## Testing

### Manual testing

I used lighthouse and siteimprove to check that the problematic behaviour was no longer flagged.

I used voice over to check that the new aria-labels were sensible.
