### PR TITLE
LIIKUNTA 188, 196 | Adjust map center and default sort order

### DIFF
--- a/src/common/components/mapView/mapConstants.ts
+++ b/src/common/components/mapView/mapConstants.ts
@@ -3,7 +3,7 @@ import { LatLngBoundsLiteral, LatLngExpression } from "leaflet";
 export const TILE_URL =
   "http://tiles.hel.ninja/styles/hel-osm-bright/{z}/{x}/{y}.png";
 
-export const DEFAULT_POSITION: LatLngExpression = [60.16687, 24.943781];
+export const DEFAULT_POSITION: LatLngExpression = [60.2087778, 24.9980714];
 
 export const DEFAULT_ZOOM = 12;
 

--- a/src/domain/search/landingPageSearchForm/LandingPageSearchForm.tsx
+++ b/src/domain/search/landingPageSearchForm/LandingPageSearchForm.tsx
@@ -4,6 +4,7 @@ import classNames from "classnames";
 import { useTranslation } from "next-i18next";
 
 import useUnifiedSearch from "../../unifiedSearch/useUnifiedSearch";
+import { OrderBy } from "../../unifiedSearch/unifiedSearchConstants";
 import Link from "../../i18n/router/Link";
 import Text from "../../../common/components/text/Text";
 import SecondaryLink from "../../../common/components/link/SecondaryLink";
@@ -16,7 +17,7 @@ function LandingPageSearchForm() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setFilters({ q: [searchText] }, "/search");
+    setFilters({ q: [searchText], orderBy: OrderBy.relevance }, "/search");
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -11,9 +11,10 @@ import useAdministrativeDivisions from "../../unifiedSearch/administrativeDivisi
 import OntologyTreeDropdown from "../../unifiedSearch/ontologyTreeDropdown/OntologyTreeDropdown";
 import useOntologyTree from "../../unifiedSearch/ontologyTreeDropdown/useOntologyTree";
 import useUnifiedSearch from "../../unifiedSearch/useUnifiedSearch";
+import searchApolloClient from "../../unifiedSearch/searchApolloClient";
+import { OrderBy } from "../../unifiedSearch/unifiedSearchConstants";
 import useRouter from "../../i18n/router/useRouter";
 import Link from "../../i18n/router/Link";
-import searchApolloClient from "../../../domain/unifiedSearch/searchApolloClient";
 import { getUnifiedSearchLanguage } from "../../../common/apollo/utils";
 import getTranslation from "../../../common/utils/getTranslation";
 import { formatIntoDateTime } from "../../../common/utils/time/format";
@@ -89,6 +90,9 @@ function SearchPageSearchForm({
       ontologyTreeIds,
       isOpenNow,
       openAt,
+      // When making query, if user hasn't explicitly selected an order, default
+      // to using relevance.
+      orderBy: filters.orderBy ?? OrderBy.relevance,
     });
     setSearchText("");
   };

--- a/src/domain/unifiedSearch/types.ts
+++ b/src/domain/unifiedSearch/types.ts
@@ -1,3 +1,5 @@
+import { OrderByType, OrderDirType } from "./unifiedSearchConstants";
+
 export type UnifiedSearchParameters = {
   q?: string[];
   administrativeDivisionIds?: string[];
@@ -8,6 +10,6 @@ export type UnifiedSearchParameters = {
   ontology?: string;
   isOpenNow?: boolean;
   openAt?: Date;
-  orderBy?: "distance";
-  orderDir?: "asc" | "desc";
+  orderBy?: OrderByType;
+  orderDir?: OrderDirType;
 };

--- a/src/domain/unifiedSearch/unifiedSearchConstants.ts
+++ b/src/domain/unifiedSearch/unifiedSearchConstants.ts
@@ -1,0 +1,22 @@
+export const OrderDir = {
+  asc: "asc",
+  desc: "desc",
+} as const;
+
+export type OrderDirType = typeof OrderDir[keyof typeof OrderDir];
+
+export const OrderBy = {
+  relevance: "relevance",
+  distance: "distance",
+  name: "name",
+} as const;
+
+export type OrderByType = typeof OrderBy[keyof typeof OrderBy];
+
+export const orderDirToUnifiedSearchDistanceOrder = {
+  asc: "ASCENDING",
+  desc: "DESCENDING",
+} as const;
+
+export type UnifiedSearchOrderBy =
+  typeof orderDirToUnifiedSearchDistanceOrder[keyof typeof orderDirToUnifiedSearchDistanceOrder];

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -45,6 +45,7 @@ export const SEARCH_QUERY = gql`
     $ontologyWordIds: [ID!]
     $openAt: String
     $orderByDistance: OrderByDistance
+    $orderByName: OrderByName
   ) {
     unifiedSearch(
       q: $q
@@ -57,6 +58,7 @@ export const SEARCH_QUERY = gql`
       ontologyWordIds: $ontologyWordIds
       openAt: $openAt
       orderByDistance: $orderByDistance
+      orderByName: $orderByName
     ) {
       count
       pageInfo {

--- a/src/pages/search/map.tsx
+++ b/src/pages/search/map.tsx
@@ -38,6 +38,7 @@ export const MAP_SEARCH_QUERY = gql`
     $ontologyTreeIds: [ID!]
     $openAt: String
     $orderByDistance: OrderByDistance
+    $orderByName: OrderByName
   ) {
     unifiedSearch(
       q: $q
@@ -49,6 +50,7 @@ export const MAP_SEARCH_QUERY = gql`
       ontologyTreeIds: $ontologyTreeIds
       openAt: $openAt
       orderByDistance: $orderByDistance
+      orderByName: $orderByName
     ) {
       count
       edges {


### PR DESCRIPTION
## Description

Changes the default sort order to alphabetical (by name).

When user completes a search, the search order should be set to relevance. Ordering by relevance after there are search criteria will likely makes more sense.

I've extended the sort controls to contain all sort criteria to simplify the code and UX.

Changes map default center based on the design in the linked task.

## Issues

### Closes

**[LIIKUNTA-188](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-188)**
**[LIIKUNTA-188](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-188)**
