### PR TITLE
LIIKUNTA-206 | Fit more content before the fold on landing and search page

### DIFF
--- a/src/common/components/hero/Hero.tsx
+++ b/src/common/components/hero/Hero.tsx
@@ -18,7 +18,7 @@ function Hero({ title, description, cta }: Props) {
       <span className={styles.boxHelper}>
         <HtmlToReact>{description}</HtmlToReact>
       </span>
-      <Text variant="h1" className={styles.boxTitle}>
+      <Text variant="h2" as="h1" className={styles.boxTitle}>
         {title}
       </Text>
       <Link href={cta.href}>

--- a/src/common/components/hero/hero.module.scss
+++ b/src/common/components/hero/hero.module.scss
@@ -6,13 +6,11 @@
   align-self: center;
   background-color: rgba($color-black, 70%);
   width: 20rem;
-  height: 15rem;
   margin-bottom: 10rem;
   padding: $spacing-m;
 
   @include breakpoints.respond-above(m) {
     width: 30rem;
-    height: 18rem;
   }
 }
 
@@ -22,25 +20,24 @@
 }
 
 .boxTitle {
-  font-size: $fontsize-heading-l;
   margin-top: 0;
   padding-top: 0;
   color: $color-white;
   line-height: $lineheight-s;
-  margin-bottom: $spacing-2-xl;
-
-  @include breakpoints.respond-above(m) {
-    font-size: $fontsize-heading-xl;
-  }
+  margin-bottom: $spacing-m;
 }
 
 .linkButton {
-  background-color: $color-coat-of-arms;
-  border-color: $color-coat-of-arms !important;
+  display: block;
+  margin-top: $spacing-s;
   padding: $spacing-xs;
+  width: fit-content;
+
   text-decoration: none;
   color: $color-white;
-  margin-top: $spacing-s;
+
+  background-color: $color-coat-of-arms;
+  border-color: $color-coat-of-arms !important;
 
   &:hover {
     background-color: $color-bus;

--- a/src/common/components/hero/heroImage.module.scss
+++ b/src/common/components/hero/heroImage.module.scss
@@ -23,7 +23,7 @@
   }
 
   @include breakpoints.respond-above(m) {
-    --height: 48rem;
+    --height: 76vh;
   }
 
   .image {

--- a/src/domain/search/landingPageSearchForm/landingPageSearchForm.module.scss
+++ b/src/domain/search/landingPageSearchForm/landingPageSearchForm.module.scss
@@ -4,7 +4,7 @@
 .searchForm {
   display: flex;
   flex-direction: column;
-  padding: $spacing-m $spacing-m $spacing-s;
+  padding: $spacing-s $spacing-s $spacing-xs;
 
   background-color: #464646;
 
@@ -13,7 +13,7 @@
   }
 
   @include breakpoints.respond-above(m) {
-    padding: $spacing-layout-m $spacing-layout-m $spacing-layout-s;
+    padding: $spacing-layout-s $spacing-layout-s $spacing-layout-xs;
   }
 
   @include breakpoints.respond-above(l) {

--- a/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -204,7 +204,11 @@ function SearchPageSearchForm({
 
   return (
     <div>
-      {showTitle && <Text variant="h1">{t("title")}</Text>}
+      {showTitle && (
+        <Text variant="h2" as="h1">
+          {t("title")}
+        </Text>
+      )}
       <form role="search" className={styles.form} onSubmit={handleSubmit}>
         <SuggestionInput
           name="q"

--- a/src/domain/search/searchPageSearchForm/searchPageSearchForm.module.scss
+++ b/src/domain/search/searchPageSearchForm/searchPageSearchForm.module.scss
@@ -2,7 +2,7 @@
 @import "variables";
 
 .form {
-  margin: $spacing-m 0 $spacing-4-xl;
+  margin: $spacing-m 0 $spacing-3-xl;
   display: grid;
   grid-template-columns: 1fr;
   grid-gap: $spacing-m;


### PR DESCRIPTION
## Description

Adjust sizes of elements before the fold so that more content can be shown to the use with screen sizes of `1280x720`.

The designer who requested this change has checked it initially and given a thumbs up.

## Issues

### Closes

**[LIIKUNTA-206](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-206):**

## Screenshots

<img width="1279" alt="Screenshot 2021-12-20 at 8 17 32" src="https://user-images.githubusercontent.com/9090689/146720661-12ebc3da-90d8-452d-baaa-fae8b29b07ac.png">
<img width="1279" alt="Screenshot 2021-12-20 at 8 17 39" src="https://user-images.githubusercontent.com/9090689/146720673-88d7f0e4-a3e6-423a-b8dc-5580e8bf9597.png">
<img width="1279" alt="Screenshot 2021-12-20 at 8 17 47" src="https://user-images.githubusercontent.com/9090689/146720677-605da455-2f48-47f8-b663-7ea4b588dee8.png">
<img width="1279" alt="Screenshot 2021-12-20 at 8 17 53" src="https://user-images.githubusercontent.com/9090689/146720678-0bd47420-2687-42bc-9859-23643b1dca8e.png">

