### PR TITLE
LIIKUNTA-196 | Order by name when filters are empty

### DIFF
--- a/src/domain/search/landingPageSearchForm/LandingPageSearchForm.tsx
+++ b/src/domain/search/landingPageSearchForm/LandingPageSearchForm.tsx
@@ -17,7 +17,14 @@ function LandingPageSearchForm() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setFilters({ q: [searchText], orderBy: OrderBy.relevance }, "/search");
+    setFilters(
+      {
+        q: [searchText],
+        // Order by relevance if a search filter is applied
+        orderBy: searchText ? OrderBy.relevance : undefined,
+      },
+      "/search"
+    );
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -269,7 +269,11 @@ function SearchPageSearchForm({
         {filterList.length > 0 && (
           <div className={styles.searchAsFilters}>
             {filterList.map(({ key, value }) => {
-              const queryWithout = getQueryWithout(key, value);
+              const queryWithout = {
+                ...getQueryWithout(key, value),
+                orderBy: filters.orderBy,
+                orderDir: filters.orderDir,
+              };
 
               return (
                 <Keyword

--- a/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
+++ b/src/domain/search/searchPageSearchForm/SearchPageSearchForm.tsx
@@ -83,16 +83,25 @@ function SearchPageSearchForm({
     const isOpenNowValue = e.target.isOpenNow.checked;
     // Use undefined when false to hide from UI layer
     const isOpenNow = isOpenNowValue ? isOpenNowValue : undefined;
-
-    modifyFilters({
-      q: [q],
+    const nextFilters = {
+      q,
       administrativeDivisionIds,
       ontologyTreeIds,
       isOpenNow,
       openAt,
-      // When making query, if user hasn't explicitly selected an order, default
-      // to using relevance.
-      orderBy: filters.orderBy ?? OrderBy.relevance,
+    };
+    const nextFilterCount = Object.values(nextFilters).filter(
+      (value) => value
+    ).length;
+    // If user has selected search conditions, order by relevance by default.
+    // Otherwise defer by providing undefined which enables default logic.
+    const defaultOrderBy = nextFilterCount > 0 ? OrderBy.relevance : undefined;
+
+    modifyFilters({
+      ...nextFilters,
+      // Wrap q into array to comply with API
+      q: [nextFilters.q],
+      orderBy: filters.orderBy ?? defaultOrderBy,
     });
     setSearchText("");
   };


### PR DESCRIPTION
## Description

Fixes issue where a search with empty filters would change `orderBy` into `relevance`. After this change, only searches with filters should change `orderBy` into `relevance`.

## Issues

### Closes

**[LIIKUNTA-196](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-196)**
