### PR TITLE
FIX LIIKUNTA-158 | Fix location selection links

### DIFF
--- a/src/domain/unifiedSearch/useUnifiedSearchListQuery.ts
+++ b/src/domain/unifiedSearch/useUnifiedSearchListQuery.ts
@@ -1,15 +1,20 @@
 import {
   useSearchListQuery,
   SearchListQueryVariables,
+  SearchListQuery,
 } from "./graphql/__generated__";
 import useUnifiedSearchVariables from "./useUnifiedSearchVariables";
 import searchApolloClient from "./searchApolloClient";
 
-export default function useUnifiedSearchListQuery() {
+type Config = {
+  variables?: Partial<SearchListQueryVariables>;
+};
+
+export default function useUnifiedSearchListQuery({ variables }: Config = {}) {
   const { fetchMore, ...delegated } = useSearchListQuery({
     client: searchApolloClient,
     ssr: false,
-    variables: useUnifiedSearchVariables(),
+    variables: { ...useUnifiedSearchVariables(), ...variables },
   });
 
   const handleFetchMore = (variables: Partial<SearchListQueryVariables>) =>
@@ -22,3 +27,6 @@ export default function useUnifiedSearchListQuery() {
     ...delegated,
   };
 }
+
+export type ListVenue =
+  SearchListQuery["unifiedSearch"]["edges"][number]["node"]["venue"];

--- a/src/domain/unifiedSearch/venuesByOntologyWords/VenuesByOntologyWords.tsx
+++ b/src/domain/unifiedSearch/venuesByOntologyWords/VenuesByOntologyWords.tsx
@@ -1,38 +1,17 @@
-import { useQuery, gql } from "@apollo/client";
 import { LoadingSpinner, IconLocation } from "hds-react";
 
-import { Item, Venue } from "../../../types";
+import { Item } from "../../../types";
+import { Locale } from "../../../config";
 import List from "../../../common/components/list/List";
 import Card from "../../../common/components/card/DefaultCard";
-import { Locale } from "../../../config";
+import capitalize from "../../../common/utils/capitalize";
 import getTranslation from "../../../common/utils/getTranslation";
 import useRouter from "../../i18n/router/useRouter";
-import unifiedSearchVenueFragment from "../unifiedSearchResultVenueFragment";
-import searchApolloClient from "../searchApolloClient";
-import capitalize from "../../../common/utils/capitalize";
+import useUnifiedSearchListQuery, {
+  ListVenue,
+} from "../useUnifiedSearchListQuery";
 
-const VENUES_WITH_ONTOLOGIES_QUERY = gql`
-  query LocationsWithOntologiesQuery($ontologyWordIds: [ID!]) {
-    unifiedSearch(
-      q: "*"
-      ontologyWordIds: $ontologyWordIds
-      index: "location"
-      first: 4
-    ) {
-      edges {
-        node {
-          venue {
-            ...unifiedSearchVenueFragment
-          }
-        }
-      }
-    }
-  }
-
-  ${unifiedSearchVenueFragment}
-`;
-
-function getVenuesAsItem(venues: Venue[], locale: Locale): Item[] {
+function getVenuesAsItem(venues: ListVenue[], locale: Locale): Item[] {
   return venues.map((venue) => {
     const infoLines = [
       {
@@ -77,13 +56,12 @@ type Props = {
 
 export default function VenuesWithOntologies({ ontologyWordIds = [] }: Props) {
   const { locale } = useRouter();
-  const { data, loading } = useQuery(VENUES_WITH_ONTOLOGIES_QUERY, {
-    client: searchApolloClient,
-    ssr: false,
+  const { data, loading } = useUnifiedSearchListQuery({
     variables: {
       ontologyWordIds,
+      first: 4,
+      orderByName: undefined,
     },
-    fetchPolicy: "cache-and-network",
   });
 
   if (loading) {

--- a/src/domain/venues/utils/__tests__/getVenueIdParts.ts
+++ b/src/domain/venues/utils/__tests__/getVenueIdParts.ts
@@ -1,0 +1,16 @@
+import getVenueIdParts from "../getVenueIdParts";
+
+test("should return parts correctly", () => {
+  expect(getVenueIdParts("lipas:12345")).toMatchInlineSnapshot(`
+    Object {
+      "id": "12345",
+      "source": "lipas",
+    }
+  `);
+});
+
+test("should throw error when input is incorrectly formatted", () => {
+  expect(() => getVenueIdParts("12345")).toThrowErrorMatchingInlineSnapshot(
+    `"ID is not correctly formatted"`
+  );
+});

--- a/src/domain/venues/utils/getVenueIdParts.ts
+++ b/src/domain/venues/utils/getVenueIdParts.ts
@@ -1,0 +1,9 @@
+export default function getVenueIdParts(idWithSource: string) {
+  if (!idWithSource.includes(":")) {
+    throw Error("ID is not correctly formatted");
+  }
+
+  const [source, id] = idWithSource.split(":");
+
+  return { source, id };
+}

--- a/src/domain/venues/utils/getVenuesAsItems.ts
+++ b/src/domain/venues/utils/getVenuesAsItems.ts
@@ -1,4 +1,5 @@
 import { Item } from "../../../types";
+import getVenueIdParts from "./getVenueIdParts";
 
 function limitWordCount(description: string) {
   const limit = 30;
@@ -28,19 +29,23 @@ export default function getVenuesAsItems(venues: Venue[] | undefined): Item[] {
     return [];
   }
 
-  return venues.map(({ id, name, description, pictureUrl, ontologyWords }) => ({
-    id,
-    title: name,
-    infoLines: [limitWordCount(description)],
-    href: `/venues/tprek:${id}`,
-    image: pictureUrl,
-    keywords: ontologyWords.map((ontology) => ({
-      label: ontology.label,
-      href: {
-        query: {
-          ontologyWordIds: [ontology.id],
+  return venues.map(({ id, name, description, pictureUrl, ontologyWords }) => {
+    const { id: idNumber } = getVenueIdParts(id);
+
+    return {
+      id,
+      title: name,
+      infoLines: [limitWordCount(description)],
+      href: `/venues/tprek:${idNumber ?? id}`,
+      image: pictureUrl,
+      keywords: ontologyWords.map((ontology) => ({
+        label: ontology.label,
+        href: {
+          query: {
+            ontologyWordIds: [ontology.id],
+          },
         },
-      },
-    })),
-  }));
+      })),
+    };
+  });
 }

--- a/src/pages/venues/[id]/index.tsx
+++ b/src/pages/venues/[id]/index.tsx
@@ -41,6 +41,7 @@ import renderAddressToString from "../../../common/utils/renderAddressToString";
 import hash from "../../../common/utils/hash";
 import capitalize from "../../../common/utils/capitalize";
 import styles from "./venue.module.scss";
+import getVenueIdParts from "../../../domain/venues/utils/getVenueIdParts";
 
 export const VENUE_QUERY = gql`
   query VenueQuery($id: ID!) {
@@ -82,12 +83,6 @@ export const VENUE_QUERY = gql`
     }
   }
 `;
-
-function pruneId(idWithSource: string): string {
-  const [, id] = idWithSource.split(":");
-
-  return id;
-}
 
 type DirectionPoint = {
   name: string;
@@ -466,9 +461,9 @@ export function VenuePageContent() {
             <Hr />
             <MapBox
               title={t("map_box.title")}
-              serviceMapUrl={`https://palvelukartta.hel.fi/fi/embed/unit/${pruneId(
-                id
-              )}`}
+              serviceMapUrl={`https://palvelukartta.hel.fi/fi/embed/unit/${
+                getVenueIdParts(id).id
+              }`}
               placeName={name}
               placeAddress={simplifiedAddress}
               links={[hslInfoLink, googleInfoLink]}


### PR DESCRIPTION
## Description

Previously the id from `tprek` was used as is. The id also contained its source (for instance `lipas:...`) which caused the site to build an incorrect link.

After this change the source information is ignored and it's replaced with `tprek`.

Contains a slight refactor for how parts of a venue id are parsed.

## Issues

### Closes

**[LIIKUNTA-158](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-158)**

## Testing

### Manual testing

This collections contains a venue selection: http://localhost:3000/kokoelmat/meno-ja-meininkia-viikonlopuksi

## Screenshots

<img width="912" alt="Screenshot 2022-01-03 at 14 18 00" src="https://user-images.githubusercontent.com/9090689/147929524-900cf46d-eb53-4e1e-adfe-c135688e6cde.png">

