### PR TITLE
LIIKUNTA-259 | Fix ontologies overlapping datetime picker

### DIFF
--- a/src/common/components/dateTimePicker/dateTimePicker.module.scss
+++ b/src/common/components/dateTimePicker/dateTimePicker.module.scss
@@ -54,7 +54,7 @@
       padding: 1.2rem 1.2rem;
       left: 0;
       right: 0;
-      z-index: 100;
+      z-index: 1000;
       display: flex;
       flex-flow: column;
 

--- a/src/domain/venues/utils/getVenuesAsItems.ts
+++ b/src/domain/venues/utils/getVenuesAsItems.ts
@@ -17,7 +17,7 @@ type Venue = {
   name: string;
   pictureUrl: string;
   pictureCaption: string;
-  description: string;
+  description?: string;
   ontologyWords: Array<{
     id: string;
     label: string;
@@ -35,7 +35,7 @@ export default function getVenuesAsItems(venues: Venue[] | undefined): Item[] {
     return {
       id,
       title: name,
-      infoLines: [limitWordCount(description)],
+      infoLines: description ? [limitWordCount(description)] : [],
       href: `/venues/tprek:${idNumber ?? id}`,
       image: pictureUrl,
       keywords: ontologyWords.map((ontology) => ({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7023,7 +7023,7 @@ lodash.xor@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.xor/-/lodash.xor-4.5.0.tgz#4d48ed7e98095b0632582ba714d3ff8ae8fb1db6"
   integrity sha1-TUjtfpgJWwYyWCunFNP/iuj7HbY=
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0, lodash@~4.17.0, lodash@~4.17.21:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0, lodash@~4.17.0, lodash@~4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
## Description

Changes z-index so that date time picker isn't rendered below keywords.

## Issues

### Closes

**[LIIKUNTA-259](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-259):**

## Screenshots

<img width="1221" alt="Screenshot 2022-01-10 at 14 04 17" src="https://user-images.githubusercontent.com/9090689/148763260-02a29123-69b0-429d-918b-24fbd575a5e8.png">
<img width="1221" alt="Screenshot 2022-01-10 at 14 04 21" src="https://user-images.githubusercontent.com/9090689/148763274-807dfd71-99de-48fa-b8f1-0deb791a626c.png">
