### PR TITLE
LIIKUNTA-249 | Add price information from connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "jest": "^27.3.1",
     "jest-dom": "^4.0.0",
     "prettier": "^2.4.1",
+    "react-i18next": "^11.15.3",
     "ts-jest": "^27.0.7",
     "typescript": "^4.4.4"
   },

--- a/public/locales/en/venue_page.json
+++ b/public/locales/en/venue_page.json
@@ -19,5 +19,7 @@
   "map_box.accessibility_sentences": "Accessibility",
   "other_sports_section.title": "EN: Muuta samankaltaista liikuntaa",
   "back_to_venue_page_aria_label": "EN: Takaisin liikuntapaikkasivulle",
-  "a11y_keywords_group_name": "EN: Asiasanat"
+  "a11y_keywords_group_name": "EN: Asiasanat",
+  "show_long_price": "EN: Näytä kaikki",
+  "hide_long_price": "EN: Piilota"
 }

--- a/public/locales/fi/venue_page.json
+++ b/public/locales/fi/venue_page.json
@@ -19,5 +19,7 @@
   "map_box.accessibility_sentences": "Esteettömyystiedot",
   "other_sports_section.title": "Muuta samankaltaista liikuntaa",
   "back_to_venue_page_aria_label": "Takaisin liikuntapaikkasivulle",
-  "a11y_keywords_group_name": "Asiasanat"
+  "a11y_keywords_group_name": "Asiasanat",
+  "show_long_price": "Näytä kaikki",
+  "hide_long_price": "Piilota"
 }

--- a/public/locales/sv/venue_page.json
+++ b/public/locales/sv/venue_page.json
@@ -19,5 +19,7 @@
   "map_box.accessibility_sentences": "Information om tillgängligheten",
   "other_sports_section.title": "SV: Muuta samankaltaista liikuntaa",
   "back_to_venue_page_aria_label": "SV: Takaisin liikuntapaikkasivulle",
-  "a11y_keywords_group_name": "SV: Asiasanat"
+  "a11y_keywords_group_name": "SV: Asiasanat",
+  "show_long_price": "SV: Näytä kaikki",
+  "hide_long_price": "SV: Piilota"
 }

--- a/src/common/components/dateTimePicker/__tests__/DateTimePicker.test.js
+++ b/src/common/components/dateTimePicker/__tests__/DateTimePicker.test.js
@@ -20,10 +20,10 @@ describe("DateTimePicker", () => {
     render(<TestDateInputPicker locale="en" label={label} />);
 
     userEvent.click(screen.getByRole("button", { name: label }));
-    userEvent.type(screen.getByLabelText("date_input.label"), "12.12.2012");
-    userEvent.type(screen.getByLabelText("time_input.hours_label"), "14");
-    userEvent.type(screen.getByLabelText("time_input.minutes_label"), "16");
-    userEvent.click(screen.getByRole("button", { name: "select" }));
+    userEvent.type(screen.getByLabelText("Päivä"), "12.12.2012");
+    userEvent.type(screen.getByLabelText("Tunnit"), "14");
+    userEvent.type(screen.getByLabelText("Minuutit"), "16");
+    userEvent.click(screen.getByRole("button", { name: "Valitse" }));
 
     expect(
       screen.getByLabelText(label, { exact: false }).textContent

--- a/src/common/components/ellipsedTextWithToggle/EllipsedTextWithToggle.tsx
+++ b/src/common/components/ellipsedTextWithToggle/EllipsedTextWithToggle.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import { useTranslation } from "next-i18next";
+
+import styles from "./ellipsedTextWithToggle.module.scss";
+
+type Props = {
+  lines: string[];
+};
+
+export default function EllipsedTextWithToggle({ lines }: Props) {
+  const { t } = useTranslation("venue_page");
+  const [open, setOpen] = useState<boolean>(false);
+
+  const firstLines = lines.slice(0, 3).join("\n");
+  const restOfLines = lines.slice(3).join("\n");
+
+  return (
+    <span className={styles.container}>
+      {firstLines}
+      {"\n"}
+      {open && restOfLines}
+      <button
+        type="button"
+        className={styles.button}
+        onClick={() => {
+          setOpen((prevOpen) => !prevOpen);
+        }}
+      >
+        {!open ? t("show_long_price") : t("hide_long_price")}
+      </button>
+    </span>
+  );
+}

--- a/src/common/components/ellipsedTextWithToggle/EllipsedTextWithToggle.tsx
+++ b/src/common/components/ellipsedTextWithToggle/EllipsedTextWithToggle.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import { useTranslation } from "next-i18next";
+import { useAccordion } from "hds-react";
 
 import styles from "./ellipsedTextWithToggle.module.scss";
 
@@ -9,7 +10,9 @@ type Props = {
 
 export default function EllipsedTextWithToggle({ lines }: Props) {
   const { t } = useTranslation("venue_page");
-  const [open, setOpen] = useState<boolean>(false);
+  const { isOpen, buttonProps, contentProps } = useAccordion({
+    initiallyOpen: false,
+  });
 
   const firstLines = lines.slice(0, 3).join("\n");
   const restOfLines = lines.slice(3).join("\n");
@@ -18,15 +21,13 @@ export default function EllipsedTextWithToggle({ lines }: Props) {
     <span className={styles.container}>
       {firstLines}
       {"\n"}
-      {open && restOfLines}
-      <button
-        type="button"
-        className={styles.button}
-        onClick={() => {
-          setOpen((prevOpen) => !prevOpen);
-        }}
-      >
-        {!open ? t("show_long_price") : t("hide_long_price")}
+      {isOpen && (
+        <div aria-hidden={!isOpen} {...contentProps}>
+          {restOfLines}
+        </div>
+      )}
+      <button {...buttonProps} type="button" className={styles.button}>
+        {!isOpen ? t("show_long_price") : t("hide_long_price")}
       </button>
     </span>
   );

--- a/src/common/components/ellipsedTextWithToggle/ellipsedTextWithToggle.module.scss
+++ b/src/common/components/ellipsedTextWithToggle/ellipsedTextWithToggle.module.scss
@@ -1,0 +1,19 @@
+@import "variables";
+
+.container {
+  white-space: pre-wrap;
+
+  .button {
+    display: block;
+    margin-top: $spacing-2-xs;
+    padding: 0;
+
+    font-family: inherit;
+    font-weight: 500;
+    color: $color-bus;
+
+    background: none;
+    border: none;
+    cursor: pointer;
+  }
+}

--- a/src/common/components/navigation/tests/__snapshots__/navigation.test.js.snap
+++ b/src/common/components/navigation/tests/__snapshots__/navigation.test.js.snap
@@ -9,7 +9,7 @@ exports[`<Navigation /> should render correctly 1`] = `
       class="Navigation-module_skipToContent__2p54x"
       href="#undefined"
     >
-      skip_to_content_label
+      Siirry suoraan sisältöön
     </a>
     <div
       class="visible-module_belowM__2GR1J"
@@ -42,7 +42,7 @@ exports[`<Navigation /> should render correctly 1`] = `
               />
             </svg>
             <span>
-              site_name
+              Liikunta Helsinki
             </span>
           </a>
           <div
@@ -105,7 +105,7 @@ exports[`<Navigation /> should render correctly 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="true"
-            aria-label="menu_toggle_aria_label"
+            aria-label="Valikko"
             class="Navigation-module_mobileMenuToggle__1v6en"
             type="button"
           >
@@ -164,7 +164,7 @@ exports[`<Navigation /> should render correctly 1`] = `
               />
             </svg>
             <span>
-              site_name
+              Liikunta Helsinki
             </span>
           </a>
           <div

--- a/src/common/components/shareLinks/tests/FacebookShareLink.test.jsx
+++ b/src/common/components/shareLinks/tests/FacebookShareLink.test.jsx
@@ -8,7 +8,7 @@ test("should apply aria label", () => {
   const sharedLink = "https://helsinki.fi/some/";
   renderComponent({ sharedLink });
 
-  expect(screen.getByLabelText("facebook"));
+  expect(screen.getByLabelText("Jaa Facebookissa"));
 });
 
 test("<FacebookShareLink /> matches snapshot", () => {

--- a/src/common/components/shareLinks/tests/LinkedInShareLink.test.jsx
+++ b/src/common/components/shareLinks/tests/LinkedInShareLink.test.jsx
@@ -8,7 +8,7 @@ test("should apply aria label", () => {
   const sharedLink = "https://helsinki.fi/some/";
   renderComponent({ sharedLink });
 
-  expect(screen.getByLabelText("linkedin"));
+  expect(screen.getByLabelText("Jaa LinkedInissä"));
 });
 
 test("<LinkedInShareLink /> matches snapshot", () => {

--- a/src/common/components/shareLinks/tests/ShareLinks.test.tsx
+++ b/src/common/components/shareLinks/tests/ShareLinks.test.tsx
@@ -6,7 +6,12 @@ const renderComponent = () => render(<ShareLinks />);
 
 test("should have discoverable link address copy button as well as Facebook, Twitter and LinkedIn share links", () => {
   renderComponent();
-  const shareLinkLabelsFI = ["copy.label", "facebook", "twitter", "linkedin"];
+  const shareLinkLabelsFI = [
+    "Kopioi linkin osoite",
+    "Jaa Facebookissa",
+    "Jaa Twitterissä",
+    "Jaa LinkedInissä",
+  ];
 
   shareLinkLabelsFI.forEach((label) => {
     expect(screen.queryByLabelText(label)).not.toEqual(null);

--- a/src/common/components/shareLinks/tests/TwitterShareLink.test.jsx
+++ b/src/common/components/shareLinks/tests/TwitterShareLink.test.jsx
@@ -8,7 +8,7 @@ test("should apply aria label", () => {
   const sharedLink = "https://helsinki.fi/some/";
   renderComponent({ sharedLink });
 
-  expect(screen.getByLabelText("twitter"));
+  expect(screen.getByLabelText("Jaa Twitterissä"));
 });
 
 test("<TwitterShareLink /> matches snapshot", () => {

--- a/src/common/components/shareLinks/tests/__snapshots__/FacebookShareLink.test.jsx.snap
+++ b/src/common/components/shareLinks/tests/__snapshots__/FacebookShareLink.test.jsx.snap
@@ -2,8 +2,8 @@
 
 exports[`<FacebookShareLink /> matches snapshot 1`] = `
 <button
-  aria-label="facebook"
-  title="facebook"
+  aria-label="Jaa Facebookissa"
+  title="Jaa Facebookissa"
   type="button"
 >
   <svg

--- a/src/common/components/shareLinks/tests/__snapshots__/LinkedInShareLink.test.jsx.snap
+++ b/src/common/components/shareLinks/tests/__snapshots__/LinkedInShareLink.test.jsx.snap
@@ -2,8 +2,8 @@
 
 exports[`<LinkedInShareLink /> matches snapshot 1`] = `
 <button
-  aria-label="linkedin"
-  title="linkedin"
+  aria-label="Jaa LinkedInissä"
+  title="Jaa LinkedInissä"
   type="button"
 >
   <svg

--- a/src/common/components/shareLinks/tests/__snapshots__/TwitterShareLink.test.jsx.snap
+++ b/src/common/components/shareLinks/tests/__snapshots__/TwitterShareLink.test.jsx.snap
@@ -2,8 +2,8 @@
 
 exports[`<TwitterShareLink /> matches snapshot 1`] = `
 <button
-  aria-label="twitter"
-  title="twitter"
+  aria-label="Jaa Twitterissä"
+  title="Jaa Twitterissä"
   type="button"
 >
   <svg

--- a/src/domain/graphql/__tests__/__snapshots__/graphqlEndpointIntegration.test.js.snap
+++ b/src/domain/graphql/__tests__/__snapshots__/graphqlEndpointIntegration.test.js.snap
@@ -34,6 +34,24 @@ Object {
         },
       ],
       "addressLocality": "Helsinki",
+      "connections": Array [
+        Object {
+          "name": "Päiväkodinjohtaja",
+          "sectionType": "PHONE_OR_EMAIL",
+        },
+        Object {
+          "name": "Hakemus kerhotoimintaan, esiopetukseen ja esiopetusta täydentävään varhaiskasvatukseen",
+          "sectionType": "ESERVICE_LINK",
+        },
+        Object {
+          "name": "Kerhohakemus sähköisessä asioinnissa",
+          "sectionType": "ESERVICE_LINK",
+        },
+        Object {
+          "name": "Varhaiskasvatushakemus Asti-asiointipalvelussa",
+          "sectionType": "ESERVICE_LINK",
+        },
+      ],
       "dataSource": "tprek",
       "description": null,
       "email": "pk.lappi@hel.fi",
@@ -188,6 +206,24 @@ Object {
           },
         ],
         "addressLocality": "Helsinki",
+        "connections": Array [
+          Object {
+            "name": "Päiväkodinjohtaja",
+            "sectionType": "PHONE_OR_EMAIL",
+          },
+          Object {
+            "name": "Hakemus kerhotoimintaan, esiopetukseen ja esiopetusta täydentävään varhaiskasvatukseen",
+            "sectionType": "ESERVICE_LINK",
+          },
+          Object {
+            "name": "Kerhohakemus sähköisessä asioinnissa",
+            "sectionType": "ESERVICE_LINK",
+          },
+          Object {
+            "name": "Varhaiskasvatushakemus Asti-asiointipalvelussa",
+            "sectionType": "ESERVICE_LINK",
+          },
+        ],
         "dataSource": "tprek",
         "description": null,
         "email": "pk.lappi@hel.fi",
@@ -312,6 +348,24 @@ Object {
           },
         ],
         "addressLocality": "Helsinki",
+        "connections": Array [
+          Object {
+            "name": "Päiväkodinjohtaja",
+            "sectionType": "PHONE_OR_EMAIL",
+          },
+          Object {
+            "name": "Hakemus kerhotoimintaan, esiopetukseen ja esiopetusta täydentävään varhaiskasvatukseen",
+            "sectionType": "ESERVICE_LINK",
+          },
+          Object {
+            "name": "Kerhohakemus sähköisessä asioinnissa",
+            "sectionType": "ESERVICE_LINK",
+          },
+          Object {
+            "name": "Varhaiskasvatushakemus Asti-asiointipalvelussa",
+            "sectionType": "ESERVICE_LINK",
+          },
+        ],
         "dataSource": "tprek",
         "description": null,
         "email": "pk.lappi@hel.fi",

--- a/src/domain/graphql/__tests__/graphqlEndpointIntegration.test.js
+++ b/src/domain/graphql/__tests__/graphqlEndpointIntegration.test.js
@@ -61,6 +61,10 @@ const GET_VENUE = gql`
         id
         label
       }
+      connections {
+        sectionType
+        name
+      }
     }
   }
 `;
@@ -123,6 +127,10 @@ const GET_VENUES_BY_IDS = gql`
       ontologyTree {
         id
         label
+      }
+      connections {
+        sectionType
+        name
       }
     }
   }

--- a/src/domain/graphql/venue/instructions/VenueTprekIntegration.ts
+++ b/src/domain/graphql/venue/instructions/VenueTprekIntegration.ts
@@ -55,7 +55,12 @@ export type TprekUnit = {
   accessibility_viewpoints?: string;
   created_time: string;
   modified_time: string;
-  connections: Array<unknown>;
+  connections: Array<{
+    section_type: string;
+    name_fi: string;
+    name_en: string;
+    name_sv: string;
+  }>;
   ontologyword_details: TprekUnitOntologywordDetails[];
   service_descriptions: TprekUnitServiceDescriptions[];
   accessibility_sentences: Array<unknown>;
@@ -98,6 +103,10 @@ export default class VenueTprekIntegration extends VenueResolverIntegration<Tpre
         sv: data?.phone ?? null,
         en: data?.phone ?? null,
       },
+      connections: data?.connections?.map((connection) => ({
+        sectionType: connection.section_type,
+        name: formTranslationObject(connection, "name"),
+      })),
     };
   }
 }

--- a/src/domain/graphql/venue/instructions/utils.ts
+++ b/src/domain/graphql/venue/instructions/utils.ts
@@ -2,7 +2,6 @@ import get from "lodash/get";
 
 import { Locale } from "../../../../config";
 import {
-  AnyObject,
   Context,
   Point,
   TranslationsObject,
@@ -73,7 +72,7 @@ function pickLocale(obj: TranslationsObject, locale: Locale) {
 }
 
 export function translateVenue(
-  data: AnyObject,
+  data: Partial<VenueDetails>,
   { language }: Context
 ): VenueDetails | VenueDetails<string> {
   if (!language) {
@@ -88,6 +87,14 @@ export function translateVenue(
     streetAddress: pickLocale(data.streetAddress, language),
     infoUrl: pickLocale(data.infoUrl, language),
     telephone: pickLocale(data.telephone, language),
-    accessibilitySentences: pickLocale(data.accessibilitySentences, language),
+    accessibilitySentences:
+      // If grouped by translations, find the correct one by language
+      "fi" in data.accessibilitySentences
+        ? get(data.accessibilitySentences, language, null)
+        : data.accessibilitySentences,
+    connections: data.connections.map((connection) => ({
+      ...connection,
+      name: pickLocale(connection.name, language),
+    })),
   } as VenueDetails<string>;
 }

--- a/src/domain/graphql/venue/venueResolver.ts
+++ b/src/domain/graphql/venue/venueResolver.ts
@@ -62,6 +62,9 @@ const Venue = {
 
     return accessibilitySentences;
   },
+  connections({ connections }) {
+    return connections;
+  },
 };
 
 export default Venue;

--- a/src/domain/graphql/venue/venueSchema.ts
+++ b/src/domain/graphql/venue/venueSchema.ts
@@ -51,6 +51,11 @@ const typeDefs = gql`
     sentences: [String]
   }
 
+  type Connection {
+    sectionType: String
+    name: String
+  }
+
   type Venue {
     addressLocality: String
     dataSource: String
@@ -69,6 +74,7 @@ const typeDefs = gql`
     ontologyTree: [Ontology]!
     ontologyWords: [Ontology]!
     accessibilitySentences: [AccessibilitySentences]!
+    connections: [Connection]!
   }
 `;
 

--- a/src/pages/venues/[id]/index.tsx
+++ b/src/pages/venues/[id]/index.tsx
@@ -7,6 +7,7 @@ import {
   IconInfoCircle,
   IconMap,
   IconAngleDown,
+  IconTicket,
 } from "hds-react";
 import React from "react";
 import classNames from "classnames";
@@ -29,6 +30,7 @@ import serverSideTranslationsWithCommon from "../../../domain/i18n/serverSideTra
 import { getLocaleOrError } from "../../../domain/i18n/router/utils";
 import UpcomingEventsSection from "../../../domain/events/upcomingEventsSection/UpcomingEventsSection";
 import VenuesByOntologyWords from "../../../domain/unifiedSearch/venuesByOntologyWords/VenuesByOntologyWords";
+import getVenueIdParts from "../../../domain/venues/utils/getVenueIdParts";
 import Keyword from "../../../common/components/keyword/Keyword";
 import Page from "../../../common/components/page/Page";
 import Text from "../../../common/components/text/Text";
@@ -37,11 +39,11 @@ import ShareLinks from "../../../common/components/shareLinks/ShareLinks";
 import MapBox from "../../../common/components/mapBox/MapBox";
 import Hr from "../../../common/components/hr/Hr";
 import Section from "../../../common/components/section/Section";
+import EllipsedTextWithToggle from "../../../common/components/ellipsedTextWithToggle/EllipsedTextWithToggle";
 import renderAddressToString from "../../../common/utils/renderAddressToString";
 import hash from "../../../common/utils/hash";
 import capitalize from "../../../common/utils/capitalize";
 import styles from "./venue.module.scss";
-import getVenueIdParts from "../../../domain/venues/utils/getVenueIdParts";
 
 export const VENUE_QUERY = gql`
   query VenueQuery($id: ID!) {
@@ -79,6 +81,10 @@ export const VENUE_QUERY = gql`
       ontologyWords {
         id
         label
+      }
+      connections {
+        sectionType
+        name
       }
     }
   }
@@ -264,13 +270,26 @@ export function VenuePageContent() {
       ))}
     />
   );
+  const connectionPriceSectionsContents = data?.venue?.connections
+    ?.filter((item) => item.sectionType === "PRICE")
+    ?.map((item) => item.name);
+  const connectionPriceSectionsLines = connectionPriceSectionsContents
+    .join("\n\n")
+    .split("\n");
   const infoLines = [
     {
       id: "address",
       icon: <IconLocation aria-hidden="true" />,
       info: simplifiedAddress,
     },
-  ];
+    connectionPriceSectionsContents.length > 0
+      ? {
+          id: "price",
+          icon: <IconTicket aria-hidden="true" />,
+          info: <EllipsedTextWithToggle lines={connectionPriceSectionsLines} />,
+        }
+      : null,
+  ].filter((item) => Boolean(item));
   const ontologyWords = data?.venue?.ontologyWords?.map((ontology) => ({
     label: capitalize(ontology.label),
     id: ontology.id,

--- a/src/pages/venues/[id]/venue.module.scss
+++ b/src/pages/venues/[id]/venue.module.scss
@@ -100,7 +100,7 @@
       height: 100%;
     }
 
-    background-color: $color-white;
+    background-color: #e0faf4;
 
     & > * {
       max-height: 31rem;

--- a/src/pages/venues/[id]/venue.module.scss
+++ b/src/pages/venues/[id]/venue.module.scss
@@ -18,7 +18,7 @@
     display: block;
     grid-column: full-width;
     grid-row: 1;
-    height: 31rem;
+    min-height: 31rem;
 
     @include breakpoints.respond-above(m) {
       background-color: #ccf7ed;
@@ -97,11 +97,12 @@
     overflow: hidden;
 
     @include breakpoints.respond-above(m) {
-      max-height: 31rem;
+      height: 100%;
     }
 
-    & > img {
-      object-fit: cover;
+    background-color: $color-white;
+
+    & > * {
       max-height: 31rem;
     }
   }
@@ -127,10 +128,6 @@
         margin-bottom: $spacing-2-xl;
       }
     }
-
-    @include breakpoints.respond-above(l) {
-      --spacing-v: #{$spacing-layout-xl};
-    }
   }
 
   .keywords {
@@ -154,9 +151,11 @@
 
     .headerInfoLine {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
 
       & > svg {
+        width: 24px;
+        flex-shrink: 0;
         margin-right: $spacing-xs;
       }
     }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,25 +4,17 @@ import "@testing-library/jest-dom/extend-expect";
 import { loadEnvConfig } from "@next/env";
 
 import { server } from "./domain/mocks/server";
+import "./tests/initI18n";
 
 loadEnvConfig(process.cwd());
 
 global.fetch = jest.fn();
 
-// https://react.i18next.com/misc/testing
-jest.mock("react-i18next", () => ({
-  // this mock makes sure any components using the translate hook can use it without a warning being shown
-  useTranslation: () => {
-    return {
-      t: (str) => str,
-      i18n: {
-        changeLanguage: () =>
-          new Promise(() => {
-            // pass
-          }),
-      },
-    };
-  },
+jest.mock("next-i18next", () => ({
+  // When testing, i18n is set up with providers instead of the version that's
+  // optimized for next. That's why we replace the next useTranslation with the
+  // default react version.
+  useTranslation: jest.requireActual("react-i18next").useTranslation,
 }));
 
 // To avoid error: ReferenceError: TextEncoder is not defined

--- a/src/tests/TestProviders.tsx
+++ b/src/tests/TestProviders.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import { RouterContext } from "next/dist/shared/lib/router-context";
 import { NextRouter } from "next/router";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { I18nextProvider } from "react-i18next";
+
+import i18n from "./initI18n";
 
 const mockRouter: NextRouter = {
   basePath: "",
@@ -36,11 +39,13 @@ type Props = {
 
 function TestProviders({ mocks, children, router }: Props) {
   return (
-    <RouterContext.Provider value={{ ...mockRouter, ...router }}>
-      <MockedProvider mocks={mocks} addTypename={false}>
-        {children}
-      </MockedProvider>
-    </RouterContext.Provider>
+    <I18nextProvider i18n={i18n}>
+      <RouterContext.Provider value={{ ...mockRouter, ...router }}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          {children}
+        </MockedProvider>
+      </RouterContext.Provider>
+    </I18nextProvider>
   );
 }
 

--- a/src/tests/index.test.tsx
+++ b/src/tests/index.test.tsx
@@ -61,7 +61,7 @@ test("renders correctly", async () => {
     expect(screen.getByText("Kesän parhaat uimarannat")).toBeInTheDocument()
   );
 
-  ["outdoor_gyms", "swimming_summer", "skating"].forEach((shortcutLabel) => {
+  ["Ulkokuntosalit", "Uinti", "Skeittaus"].forEach((shortcutLabel) => {
     expect(
       screen.getByRole("link", { name: shortcutLabel })
     ).toBeInTheDocument();

--- a/src/tests/initI18n.ts
+++ b/src/tests/initI18n.ts
@@ -1,0 +1,68 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import card from "../../public/locales/fi/card.json";
+import collection_count_label from "../../public/locales/fi/collection_count_label.json";
+import collection_page from "../../public/locales/fi/collection_page.json";
+import common from "../../public/locales/fi/common.json";
+import date_time_picker from "../../public/locales/fi/date_time_picker.json";
+import footer from "../../public/locales/fi/footer.json";
+import geolocation_provider from "../../public/locales/fi/geolocation_provider.json";
+import hardcoded_shortcuts from "../../public/locales/fi/hardcoded_shortcuts.json";
+import home_page from "../../public/locales/fi/home_page.json";
+import info_block from "../../public/locales/fi/info_block.json";
+import landing_page_search_form from "../../public/locales/fi/landing_page_search_form.json";
+import map_box from "../../public/locales/fi/map_box.json";
+import map_view from "../../public/locales/fi/map_view.json";
+import multi_select_combobox from "../../public/locales/fi/multi_select_combobox.json";
+import navigation from "../../public/locales/fi/navigation.json";
+import search_header from "../../public/locales/fi/search_header.json";
+import search_list from "../../public/locales/fi/search_list.json";
+import search_page_search_form from "../../public/locales/fi/search_page_search_form.json";
+import search_page from "../../public/locales/fi/search_page.json";
+import share_links from "../../public/locales/fi/share_links.json";
+import toast from "../../public/locales/fi/toast.json";
+import upcoming_events_section from "../../public/locales/fi/upcoming_events_section.json";
+import venue_page from "../../public/locales/fi/venue_page.json";
+
+const translation = {
+  card,
+  collection_count_label,
+  collection_page,
+  common,
+  date_time_picker,
+  footer,
+  geolocation_provider,
+  hardcoded_shortcuts,
+  home_page,
+  info_block,
+  landing_page_search_form,
+  map_box,
+  map_view,
+  multi_select_combobox,
+  navigation,
+  search_header,
+  search_list,
+  search_page_search_form,
+  search_page,
+  share_links,
+  toast,
+  upcoming_events_section,
+  venue_page,
+};
+
+i18n.use(initReactI18next).init({
+  lng: "fi",
+  fallbackLng: "fi",
+  interpolation: {
+    escapeValue: false, // react already safes from xss
+  },
+  react: {
+    useSuspense: false,
+  },
+  resources: {
+    fi: translation,
+  },
+});
+
+export default i18n;

--- a/src/tests/venues/[id].test.jsx
+++ b/src/tests/venues/[id].test.jsx
@@ -1,5 +1,4 @@
 import userEvent from "@testing-library/user-event";
-import { act } from "react-dom/test-utils";
 
 import { VENUE_QUERY, VenuePageContent } from "../../pages/venues/[id]";
 import { render, screen, waitFor } from "../utils";
@@ -28,19 +27,13 @@ const getMocks = () => [
 ];
 
 test("venues/[id] renders correctly", async () => {
-  await act(async () => {
-    render(<VenuePageContent />, getMocks(), {
-      query: {
-        id,
-      },
-    });
+  render(<VenuePageContent />, getMocks(), {
+    query: {
+      id,
+    },
   });
 
-  await waitFor(() =>
-    expect(
-      screen.getByText("Eiran uimaranta", { selector: "h2" })
-    ).toBeInTheDocument()
-  );
+  await waitFor(() => screen.getByText("Eiran uimaranta", { selector: "h2" }));
 
   // -- Check that the user can access price information correctly
   const allPriceConnectionsContentLines = defaultConnections
@@ -63,5 +56,5 @@ test("venues/[id] renders correctly", async () => {
 
   userEvent.click(screen.getByRole("button", { name: "show_long_price" }));
   // After clicking user can view all price information
-  expect(screen.getByText(allPriceConnectionsContent)).toBeInTheDocument();
+  expect(screen.queryByText(allPriceConnectionsContent)).toBeInTheDocument();
 });

--- a/src/tests/venues/[id].test.jsx
+++ b/src/tests/venues/[id].test.jsx
@@ -49,12 +49,13 @@ test("venues/[id] renders correctly", async () => {
   // User sees the beginning of the price
   expect(screen.getByText(startOfFirstPriceConnection)).toBeInTheDocument();
 
-  const allPriceConnectionsContent = allPriceConnectionsContentLines
+  const restOfPriceConnectionsContent = allPriceConnectionsContentLines
+    .slice(3)
     // Join with a space, but replace all double spaces with a single space
     .join(" ")
     .replace(/\s\s+/g, " ");
 
   userEvent.click(screen.getByRole("button", { name: "Näytä kaikki" }));
   // After clicking user can view all price information
-  expect(screen.queryByText(allPriceConnectionsContent)).toBeInTheDocument();
+  expect(screen.queryByText(restOfPriceConnectionsContent)).toBeInTheDocument();
 });

--- a/src/tests/venues/[id].test.jsx
+++ b/src/tests/venues/[id].test.jsx
@@ -54,7 +54,7 @@ test("venues/[id] renders correctly", async () => {
     .join(" ")
     .replace(/\s\s+/g, " ");
 
-  userEvent.click(screen.getByRole("button", { name: "show_long_price" }));
+  userEvent.click(screen.getByRole("button", { name: "Näytä kaikki" }));
   // After clicking user can view all price information
   expect(screen.queryByText(allPriceConnectionsContent)).toBeInTheDocument();
 });

--- a/src/tests/venues/mocks/[id].tsx
+++ b/src/tests/venues/mocks/[id].tsx
@@ -1,0 +1,136 @@
+/* eslint-disable max-len */
+
+import { getOpeningHoursForWeek } from "../../mockData/getOpeningHours";
+
+export const defaultConnections = [
+  {
+    __typename: "Connection",
+    sectionType: "OPENING_HOURS",
+    name: "Poikkeusaukioloajat\n28.12.2021-24.1.2022 suljettu",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "OPENING_HOURS",
+    name: "HUOM! \nEdellytämme koronapassia ja henkilöllisyystodistusta kaikilta yli 16-vuotiailta.",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "OPENING_HOURS",
+    name: "Sisäänpääsyajat 30.8.2021 alkaen\n\nNaiset (uintiaika 2 h)\nmaanantaisin \n1. krs 12.00 - 20.00\n2. krs suljettu \nkeskiviikkoisin \n1. krs 6.30 - 20.00\n2. krs 13.00 - 20.00 \nperjantaisin \n1. krs 6.30 - 20.00\n2. krs 13.00 - 20.00 \nsunnuntaisin \n1. krs 11.00 - 20.00\n2. krs 13.00 - 20.00 \nerityisuimakortilla \n1. krs 9.00 - 10.00",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "OPENING_HOURS",
+    name: "Miehet (uintiaika 2 h) \ntiistaisin \n1. krs 6.30 - 20.00 \n2. krs 13.00 - 20.00 \ntorstaisin \n1. krs 6.30 - 20.00 \n2. krs 13.00 - 20.00 \nlauantaisin \n1. krs 7.00 - 20.00 \n2. krs 13.00 - 20.00 \nsunnuntaisin\nerityisuimakortilla \n1. krs 7.00 - 8.00",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "OPENING_HOURS",
+    name: "Uintiaika päättyy 30 min kassan sulkemisajan jälkeen. Hallista tulee poistua viimeistään kello 21.00.\n\nHuom! Keskiviikko- ja torstaiaamuisin saunatiloissa siivotaan uimahallin aukioloaikana. Yrjönkadun uimahallissa allas ja uimaradat ovat aukioloaikoina vapaassa käytössä, eikä niitä voi varata erikseen omaan käyttöön.",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "HIGHLIGHT",
+    name: "Uimahallit ja sisäliikuntatilat ovat kiinni 28.12.2021 - 10.1.2022.",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "PHONE_OR_EMAIL",
+    name: "Kassa",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "PHONE_OR_EMAIL",
+    name: "Liikunnanohjaus",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "PHONE_OR_EMAIL",
+    name: "Tiimiesihenkilö",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "LINK",
+    name: "Hintaryhmien määrittelyt",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "LINK",
+    name: "Asiakaskortin sopimusehdot",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "LINK",
+    name: "Uimapukuohjeistus",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "LINK",
+    name: "Erityisuimakortti",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "LINK",
+    name: "Järjestyssäännöt",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "LINK",
+    name: "Nettilippu 2. kerrokseen",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "LINK",
+    name: "Tilaussaunat",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "LINK",
+    name: "Cafe Yrjö",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "LINK",
+    name: "Vesijumpat ke 7.45 - 8.15 ja pe 7.30 - 8.00",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "PRICE",
+    name: "Aikuiset \n- kertamaksu 5,50 e \n- 10 kerran sarjakortti tai kk-kortti (30 pv) 44 e\n- kausikortti (120 pv) 132 e\n\nLapset (7-17 v.) ja Muut \n- kertamaksu 3 e\n- 10 kerran sarjakortti tai kk-kortti (30 pv) 24 e\n- kausikortti (120 pv) 72 e\n\n- henkilökohtainen asiakaskortti (kausi-, kuukausi- ja sarjaliput) 4 e\n- pyyhe 7 e\n- uimapuku 7 e\n- kylpytakki 10 e\n- pefletti, saippua, shampoo 1 e/kpl\n- istumahyttilisä 1 e",
+  },
+  {
+    __typename: "Connection",
+    sectionType: "PRICE",
+    name: "2. krs (uinti 1. kerroksen altaassa)\nAikuiset\n- kertamaksu 16 e\nLapset (7-17 v.) ja Muut \n- kertamaksu 11 e\n\nSisältää: lepohytti, pyyhe, kylpytakki (saatavuuden mukaan), pefletti, uinti, höyrysauna, puulämmitteinen sauna ja infrapunasauna.",
+  },
+];
+
+export const getVenue = (overrides) => ({
+  addressLocality: "Helsinki",
+  dataSource: "",
+  description: "",
+  email: "",
+  id: "tprek:123",
+  image: "",
+  infoUrl: "https://hel.fi",
+  name: "Eiran uimaranta",
+  position: {
+    type: "Point",
+    coordinates: [1, 2],
+  },
+  postalCode: "00001",
+  streetAddress: "Eirantie 3",
+  telephone: "+35812345678",
+  openingHours: getOpeningHoursForWeek(),
+  isOpen: false,
+  ontologyTree: [],
+  ontologyWords: [],
+  accessibilitySentences: [
+    {
+      groupName: "Pääsisäänkäynti",
+      sentences: ["Erottuu selkeästi", "Ahdas tuulikaappi"],
+    },
+  ],
+  connections: defaultConnections,
+  ...overrides,
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,6 +203,10 @@ export type VenueDetails<T = TranslationsObject> = {
   accessibilitySentences:
     | AccessibilityTranslationsObject
     | AccessibilitySentences;
+  connections: Array<{
+    sectionType: string;
+    name: T;
+  }>;
 };
 
 export type Source = typeof Sources[keyof typeof Sources];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5491,7 +5491,7 @@ html-encoding-sniffer@^3.0.0:
   dependencies:
     whatwg-encoding "^2.0.0"
 
-html-escaper@^2.0.0:
+html-escaper@^2.0.0, html-escaper@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
@@ -7023,7 +7023,7 @@ lodash.xor@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.xor/-/lodash.xor-4.5.0.tgz#4d48ed7e98095b0632582ba714d3ff8ae8fb1db6"
   integrity sha1-TUjtfpgJWwYyWCunFNP/iuj7HbY=
 
-lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.7.0, lodash@~4.17.0, lodash@~4.17.21:
+lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0, lodash@~4.17.0, lodash@~4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8146,6 +8146,15 @@ react-fast-compare@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-i18next@^11.15.3:
+  version "11.15.3"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.15.3.tgz#7608fb3cacc02ac75a62fc2d68b579f140b198dd"
+  integrity sha512-RSUEM4So3Tu2JHV0JsZ5Yje+4nz66YViMfPZoywxOy0xyn3L7tE2CHvJ7Y9LUsrTU7vGmZ5bwb8PpjnkatdIxg==
+  dependencies:
+    "@babel/runtime" "^7.14.5"
+    html-escaper "^2.0.2"
+    html-parse-stringify "^3.0.1"
 
 react-i18next@^11.8.13:
   version "11.11.4"


### PR DESCRIPTION
## Description

Adds `connections` as an available field into the venue resolver in the BFF graphql endpoint.

Lists price sections from `connections` on the Venua page.

The user should see the first few lines by default and be able to expand the view to show all price related information.

The formatting that the sections contain are respected. Line changes are rendered.

## Issues

**[LIIKUNTA-249](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-249):**

## Testing

### Automated tests

Added light test coverage for the graphql endpoint and user facing UI.

### Manual testing

Yrjönkadun uimahalli has pricing related data: `paikat/tprek:41102`

## Screenshots

<img width="1680" alt="Screenshot 2022-01-11 at 12 07 37" src="https://user-images.githubusercontent.com/9090689/148922853-4406b069-b18a-4c88-ae0e-36b2f9491dc4.png">

