### PR TITLE
LIIKUNTA-268 | Show initially 4 of price information in location page

### DIFF
--- a/src/pages/venues/[id]/index.tsx
+++ b/src/pages/venues/[id]/index.tsx
@@ -285,7 +285,12 @@ export function VenuePageContent() {
       ? {
           id: "price",
           icon: <IconTicket aria-hidden="true" />,
-          info: <EllipsedTextWithToggle lines={connectionPriceSectionsLines} />,
+          info: (
+            <EllipsedTextWithToggle
+              lines={connectionPriceSectionsLines}
+              initialVisibleLinesCount={4}
+            />
+          ),
         }
       : null,
     openingHoursNow

--- a/src/tests/venues/[id].test.jsx
+++ b/src/tests/venues/[id].test.jsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor } from "../utils";
 import { getVenue, defaultConnections } from "./mocks/[id]";
 
 const id = "tprek:25";
+const initialPriceLines = 4;
 const getMocks = () => [
   {
     request: {
@@ -67,13 +68,13 @@ test("venues/[id] renders correctly", async () => {
     defaultConnections.filter((item) => item.sectionType === "PRICE")
   );
   const startOfFirstPriceConnection = stringifyLines(
-    allPriceConnectionsContentLines.slice(0, 3)
+    allPriceConnectionsContentLines.slice(0, initialPriceLines)
   );
   // User sees the beginning of the price
   expect(screen.getByText(startOfFirstPriceConnection)).toBeInTheDocument();
 
   const restOfPriceConnectionsContent = stringifyLines(
-    allPriceConnectionsContentLines.slice(3)
+    allPriceConnectionsContentLines.slice(initialPriceLines)
   );
 
   userEvent.click(screen.getAllByRole("button", { name: "Näytä kaikki" })[0]);


### PR DESCRIPTION
## Description

Show initially 4 of price information in location page

## Issues

### Closes

**[LIIKUNTA-268](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-268):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

<img width="378" alt="Screenshot 2022-01-21 at 10 00 09" src="https://user-images.githubusercontent.com/15219142/150489029-988d6694-bddf-4198-ba13-ec250a45cae6.png">


## Additional notes
