### PR TITLE
Always import useTranslation from next-i18next

### DIFF
--- a/src/common/components/card/CondensedCard.tsx
+++ b/src/common/components/card/CondensedCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { Item } from "../../../types";
 import Card from "./Card";

--- a/src/common/components/dateTimePicker/DateTimePicker.tsx
+++ b/src/common/components/dateTimePicker/DateTimePicker.tsx
@@ -16,7 +16,7 @@ import {
   IconCross,
 } from "hds-react";
 import classNames from "classnames";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 import { format, isAfter, isBefore, parse } from "date-fns";
 
 import useIntermediaryState from "../../hooks/useIntermediaryState";

--- a/src/common/geolocation/GeolocationProvider.tsx
+++ b/src/common/geolocation/GeolocationProvider.tsx
@@ -5,7 +5,7 @@ import {
   useCallback,
   ReactNode,
 } from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { Coordinates } from "../../types";
 import sendNotification from "../utils/sendToast";

--- a/src/common/utils/sendToast.tsx
+++ b/src/common/utils/sendToast.tsx
@@ -1,6 +1,6 @@
 import { toast, ToastContentProps } from "react-toastify";
 import { Notification, NotificationType, NotificationProps } from "hds-react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 type NotificationOptions = Omit<Partial<NotificationProps>, "size">;
 

--- a/src/pages/venues/[id]/map/index.tsx
+++ b/src/pages/venues/[id]/map/index.tsx
@@ -3,7 +3,7 @@ import { IconArrowLeft } from "hds-react";
 import { GetStaticPropsContext } from "next";
 import dynamic from "next/dynamic";
 import React from "react";
-import { useTranslation } from "react-i18next";
+import { useTranslation } from "next-i18next";
 
 import { VENUE_QUERY } from "..";
 import Page from "../../../../common/components/page/Page";


### PR DESCRIPTION
## Description

Always imports `useTranslation` from `next-i18next` so that the hooks has the correct translation context.

<!-- ## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**-->
