### PR TITLE
LIIKUNTA-269 | Fix language changing problem in venue page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,6 @@
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/func-call-spacing": ["error"],
-    "@typescript-eslint/member-ordering": ["warn"],
     "@typescript-eslint/no-require-imports": ["error"],
     "react/no-unused-prop-types": ["warn", { "skipShapeProps": true }],
     "array-bracket-spacing": ["warn", "never"],

--- a/src/domain/clients/cmsApolloClient.ts
+++ b/src/domain/clients/cmsApolloClient.ts
@@ -11,7 +11,7 @@ import { sortMenuItems } from "../../common/apollo/utils";
 
 const cmsApolloClient = new MutableReference<LiikuntaApolloClient>();
 
-function createCmsApolloClient() {
+export function createCmsApolloClient() {
   return new LiikuntaApolloClient({
     ssrMode: !process.browser,
     uri: Config.cmsGraphqlEndpoint,

--- a/src/domain/clients/nextApiApolloClient.ts
+++ b/src/domain/clients/nextApiApolloClient.ts
@@ -43,28 +43,30 @@ function getHttpLink(uri: string) {
   return new HttpLink(options);
 }
 
-const cache: InMemoryCache = new InMemoryCache({
-  typePolicies: {
-    Query: {
-      fields: {
-        events: relayStylePagination(["type", "where"]),
+function createInMemoryCache(): InMemoryCache {
+  return new InMemoryCache({
+    typePolicies: {
+      Query: {
+        fields: {
+          events: relayStylePagination(["type", "where"]),
+        },
       },
-    },
-    Ontology: {
-      fields: {
-        label: {
-          read(label) {
-            return capitalize(label);
+      Ontology: {
+        fields: {
+          label: {
+            read(label) {
+              return capitalize(label);
+            },
           },
         },
       },
     },
-  },
-});
+  });
+}
 
-function createNextApiApolloClient() {
+export function createNextApiApolloClient() {
   return new ApolloClient({
-    cache,
+    cache: createInMemoryCache(),
     link: getHttpLink(Config.nextApiGraphqlEndpoint),
     ssrMode: !process.browser,
   });

--- a/src/pages/venues/[id]/index.tsx
+++ b/src/pages/venues/[id]/index.tsx
@@ -19,8 +19,9 @@ import { useInView } from "react-intersection-observer";
 import noImagePlaceholder from "../../../../public/no_image.svg";
 import { Address, Point } from "../../../types";
 import { staticGenerationLogger } from "../../../domain/logger";
-import initializeCmsApollo from "../../../domain/clients/cmsApolloClient";
-import initializeNextApiApolloClient, {
+import { createCmsApolloClient } from "../../../domain/clients/cmsApolloClient";
+import {
+  createNextApiApolloClient,
   useNextApiApolloClient,
 } from "../../../domain/clients/nextApiApolloClient";
 import useRouter from "../../../domain/i18n/router/useRouter";
@@ -556,8 +557,8 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps(context: GetStaticPropsContext) {
-  const cmsClient = initializeCmsApollo();
-  const nextApiClient = initializeNextApiApolloClient();
+  const cmsClient = createCmsApolloClient();
+  const nextApiClient = createNextApiApolloClient();
 
   try {
     await cmsClient.pageQuery({

--- a/src/pages/venues/[id]/map/index.tsx
+++ b/src/pages/venues/[id]/map/index.tsx
@@ -7,8 +7,9 @@ import { useTranslation } from "next-i18next";
 
 import { VENUE_QUERY } from "..";
 import Page from "../../../../common/components/page/Page";
-import initializeCmsApollo from "../../../../domain/clients/cmsApolloClient";
-import initializeNextApiApolloClient, {
+import { createCmsApolloClient } from "../../../../domain/clients/cmsApolloClient";
+import {
+  createNextApiApolloClient,
   useNextApiApolloClient,
 } from "../../../../domain/clients/nextApiApolloClient";
 import Link from "../../../../domain/i18n/router/Link";
@@ -94,8 +95,8 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps(context: GetStaticPropsContext) {
-  const nextApiClient = initializeNextApiApolloClient();
-  const cmsClient = initializeCmsApollo();
+  const cmsClient = createCmsApolloClient();
+  const nextApiClient = createNextApiApolloClient();
 
   try {
     await cmsClient.pageQuery({


### PR DESCRIPTION
## Description

Changing language didn't change the language of venue's fields on the venue page. Main issue was that we were using same apollo client in server side between requests. I think new apollo client with empty cache should be created with every revalidation. Now we can still use `Accept-Language` header to request different languages.

## Issues

### Closes

**[LIIKUNTA-269](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-269):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

## Additional notes
