### PR TITLE
LIIKUNTA-264 | Add missing translations

### DIFF
--- a/public/locales/en/card.json
+++ b/public/locales/en/card.json
@@ -1,5 +1,5 @@
 {
   "go_to_content": "Jump to content",
-  "a11y_default_keywords_group_name": "EN: Asiasanat",
-  "read_more": "EN: Lue lisää"
+  "a11y_default_keywords_group_name": "Key words",
+  "read_more": "Read more"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,3 +1,3 @@
 {
-  "site_name": "EN_Liikunta Helsinki"
+  "site_name": "Sports Helsinki"
 }

--- a/public/locales/en/geolocation_provider.json
+++ b/public/locales/en/geolocation_provider.json
@@ -1,7 +1,7 @@
 {
-  "error.title": "EN: Sijaintia ei voitu käyttää",
-  "error.description.permission_denied": "EN: Et ole myöntänyt lupaa sijaintisi käyttämiseen",
-  "error.description.generic": "EN: Sijaintia ei ole saatavilla",
-  "a11ymessage.title": "EN: Etsitään paikkaa",
-  "a11ymessage.description": "EN: Yritämme käyttää selaimesi tarjoamaa paikkatietoa"
+  "error.title": "Location could not be displayed",
+  "error.description.permission_denied": "You have not given permission to use your location",
+  "error.description.generic": "Location not available",
+  "a11ymessage.title": "Searching for location",
+  "a11ymessage.description": "We are trying to use your browser’s location data"
 }

--- a/public/locales/en/hardcoded_shortcuts.json
+++ b/public/locales/en/hardcoded_shortcuts.json
@@ -1,12 +1,12 @@
 {
-  "outdoor_gyms": "EN: Ulkokuntosalit",
-  "swimming_summer": "EN: Uinti",
-  "swimming_winter": "EN: Uinti",
-  "sports_halls": "EN: Liikuntahallit",
-  "gyms": "EN: Kuntosalit",
-  "outdoor_activities": "EN: Ulkoilu",
-  "skating": "EN: Skeittaus",
-  "playgrounds": "EN: Leikkipuistot",
-  "ice_skating": "EN: Luistelu",
-  "skiing": "EN: Hiihto"
+  "outdoor_gyms": "Outdoor gyms",
+  "swimming_summer": "Swimming",
+  "swimming_winter": "Swimming",
+  "sports_halls": "Sports halls",
+  "gyms": "Gyms",
+  "outdoor_activities": "Outdoor recreation",
+  "skating": "Skateboarding",
+  "playgrounds": "Playgrounds",
+  "ice_skating": "Ice skating",
+  "skiing": "Cross-country skiing"
 }

--- a/public/locales/en/map_box.json
+++ b/public/locales/en/map_box.json
@@ -1,4 +1,4 @@
 {
-  "open_map": "EN: Avaa kartta",
+  "open_map": "Open map",
   "opens_in_new_tab": "Opens in a new tab"
 }

--- a/public/locales/en/navigation.json
+++ b/public/locales/en/navigation.json
@@ -1,4 +1,4 @@
 {
-  "skip_to_content_label": "EN_Siirry suoraan sisältöön",
-  "menu_toggle_aria_label": "EN_Valikko"
+  "skip_to_content_label": "Go directly to content",
+  "menu_toggle_aria_label": "Menu"
 }

--- a/public/locales/en/search_header.json
+++ b/public/locales/en/search_header.json
@@ -3,5 +3,5 @@
   "show_as_a_list": "Show in a list",
   "search_results_count_label": "Search results",
   "show_search_parameters": "Show search",
-  "show_search_parameters_a11y": "EN: Siirry hakulomakkeelle"
+  "show_search_parameters_a11y": "Go to the search form"
 }

--- a/public/locales/en/search_list.json
+++ b/public/locales/en/search_list.json
@@ -7,8 +7,8 @@
   "n_more_locations": "additional locations",
   "do_show_more_locations": "Show more locations",
   "no_more_results": "No further search results",
-  "order_by.alphabetical": "EN: Aakkosjärjestyksessä",
-  "order_by.relevance": "EN: Osuvuuden mukaan",
-  "order_by.distance": "EN: Lähimmät ensin",
-  "order_by.label": "EN: Järjestys"
+  "order_by.alphabetical": "Alphabetical order",
+  "order_by.relevance": "Relevance",
+  "order_by.distance": "Proximity",
+  "order_by.label": "Order"
 }

--- a/public/locales/en/search_page.json
+++ b/public/locales/en/search_page.json
@@ -1,6 +1,6 @@
 {
   "show_results_on_map": "Show on map",
-  "read_more": "EN: Lue lisää",
+  "read_more": "Read more",
   "block.opening_hours.open_now_label": "Currently open",
   "block.opening_hours.label": "Opening hours"
 }

--- a/public/locales/en/search_page_search_form.json
+++ b/public/locales/en/search_page_search_form.json
@@ -6,7 +6,7 @@
   "toggle_button_aria_label": "Open menu",
   "remove_filter_aria_label": "Clear filter",
   "clear_filters": "Clear the search criteria",
-  "ontology_tree_ids.label": "EN: Paikka",
+  "ontology_tree_ids.label": "Location",
   "ontology_tree_ids.placeholder": "Select place",
   "administrative_division_dropdown.label": "Area",
   "administrative_division_dropdown.placeholder": "Select area",

--- a/public/locales/en/utils.json
+++ b/public/locales/en/utils.json
@@ -1,4 +1,4 @@
 {
-  "open_now_and_closes": "EN: Auki tällä hetkellä, sulkeutuu",
-  "closed_now_and_opens": "EN: Kiinni tällä hetkellä, aukeaa"
+  "open_now_and_closes": "Open at the moment, closes at",
+  "closed_now_and_opens": "Closed at the moment, opens at"
 }

--- a/public/locales/en/venue_page.json
+++ b/public/locales/en/venue_page.json
@@ -17,9 +17,9 @@
   "share_sport": "Share exercise",
   "map_box.title": "Location",
   "map_box.accessibility_sentences": "Accessibility",
-  "other_sports_section.title": "EN: Muuta samankaltaista liikuntaa",
-  "back_to_venue_page_aria_label": "EN: Takaisin liikuntapaikkasivulle",
-  "a11y_keywords_group_name": "EN: Asiasanat",
-  "show_long_price": "EN: Näytä kaikki",
-  "hide_long_price": "EN: Piilota"
+  "other_sports_section.title": "Other similar sports",
+  "back_to_venue_page_aria_label": "Back to the sports location page",
+  "a11y_keywords_group_name": "Key words",
+  "show_long_price": "Show all",
+  "hide_long_price": "Hide"
 }

--- a/public/locales/sv/card.json
+++ b/public/locales/sv/card.json
@@ -1,5 +1,5 @@
 {
   "go_to_content": "Gå till innehållet",
-  "a11y_default_keywords_group_name": "SV: Asiasanat",
-  "read_more": "SV: Lue lisää"
+  "a11y_default_keywords_group_name": "Ämnesord",
+  "read_more": "Läs mer"
 }

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -1,3 +1,3 @@
 {
-  "site_name": "SV_Liikunta Helsinki"
+  "site_name": "Idrott och motion Helsingfors"
 }

--- a/public/locales/sv/geolocation_provider.json
+++ b/public/locales/sv/geolocation_provider.json
@@ -1,7 +1,7 @@
 {
-  "error.title": "SV: Sijaintia ei voitu käyttää",
-  "error.description.permission_denied": "SV: Et ole myöntänyt lupaa sijaintisi käyttämiseen",
-  "error.description.generic": "SV: Sijaintia ei ole saatavilla",
-  "a11ymessage.title": "SV:  Etsitään paikkaa",
-  "a11ymessage.description": "SV: Yritämme käyttää selaimesi tarjoamaa paikkatietoa"
+  "error.title": "Platsinformation kunde inte användas",
+  "error.description.permission_denied": "Du har inte gett tillstånd för användning av din platsinformation",
+  "error.description.generic": "Platsinformation finns inte tillgänglig",
+  "a11ymessage.title": "Platser söks",
+  "a11ymessage.description": "Vi försöker använda positionsdata från din webbläsare"
 }

--- a/public/locales/sv/hardcoded_shortcuts.json
+++ b/public/locales/sv/hardcoded_shortcuts.json
@@ -1,12 +1,12 @@
 {
-  "outdoor_gyms": "SV: Ulkokuntosalit",
-  "swimming_summer": "SV: Uinti",
-  "swimming_winter": "SV: Uinti",
-  "sports_halls": "SV: Liikuntahallit",
-  "gyms": "SV: Kuntosalit",
-  "outdoor_activities": "SV: Ulkoilu",
-  "skating": "SV: Skeittaus",
-  "playgrounds": "SV: Leikkipuistot",
-  "ice_skating": "SV: Luistelu",
-  "skiing": "SV: Hiihto"
+  "outdoor_gyms": "Utomhusgym",
+  "swimming_summer": "Simning",
+  "swimming_winter": "Simning",
+  "sports_halls": "Idrottshallar",
+  "gyms": "Gym",
+  "outdoor_activities": "Friluftsliv",
+  "skating": "Skejting",
+  "playgrounds": "Lekparker",
+  "ice_skating": "Skridskoåkning",
+  "skiing": "Skidåkning"
 }

--- a/public/locales/sv/map_box.json
+++ b/public/locales/sv/map_box.json
@@ -1,4 +1,4 @@
 {
-  "open_map": "SV: Avaa kartta",
+  "open_map": "Öppna kartan",
   "opens_in_new_tab": "Öppnas i ett nytt mellanblad"
 }

--- a/public/locales/sv/navigation.json
+++ b/public/locales/sv/navigation.json
@@ -1,4 +1,4 @@
 {
-  "skip_to_content_label": "SV_Siirry suoraan sisältöön",
-  "menu_toggle_aria_label": "SV_Valikko"
+  "skip_to_content_label": "Gå direkt till innehållet",
+  "menu_toggle_aria_label": "Meny"
 }

--- a/public/locales/sv/search_header.json
+++ b/public/locales/sv/search_header.json
@@ -3,5 +3,5 @@
   "show_as_a_list": "Visa i en lista",
   "search_results_count_label": "Sökresultat",
   "show_search_parameters": "Visa sökningen",
-  "show_search_parameters_a11y": "SV: Siirry hakulomakkeelle"
+  "show_search_parameters_a11y": "Gå till ansökningsblanketten"
 }

--- a/public/locales/sv/search_list.json
+++ b/public/locales/sv/search_list.json
@@ -7,8 +7,8 @@
   "n_more_locations": "flera lägen",
   "do_show_more_locations": "Visa flera lägen",
   "no_more_results": "Inga fler resultat",
-  "order_by.alphabetical": "SV: Aakkosjärjestyksessä",
-  "order_by.relevance": "SV: Osuvuuden mukaan",
-  "order_by.distance": "SV: Lähimmät ensin",
-  "order_by.label": "SV: Järjestys"
+  "order_by.alphabetical": "I alfabetisk ordning",
+  "order_by.relevance": "Efter relevans",
+  "order_by.distance": "Närmaste först",
+  "order_by.label": "Ordning"
 }

--- a/public/locales/sv/search_page.json
+++ b/public/locales/sv/search_page.json
@@ -1,6 +1,6 @@
 {
   "show_results_on_map": "Visa på kartan",
-  "read_more": "SV: Lue lisää",
+  "read_more": "Läs mer",
   "block.opening_hours.open_now_label": "Öppet nu",
   "block.opening_hours.label": "Öppettider"
 }

--- a/public/locales/sv/search_page_search_form.json
+++ b/public/locales/sv/search_page_search_form.json
@@ -6,7 +6,7 @@
   "toggle_button_aria_label": "Öppna menyn",
   "remove_filter_aria_label": "Ta bort filtret",
   "clear_filters": "Töm sökkriterierna",
-  "ontology_tree_ids.label": "SV: Paikka",
+  "ontology_tree_ids.label": "Plats",
   "ontology_tree_ids.placeholder": "Välj plats",
   "administrative_division_dropdown.label": "Område",
   "administrative_division_dropdown.placeholder": "Välj område",

--- a/public/locales/sv/utils.json
+++ b/public/locales/sv/utils.json
@@ -1,4 +1,4 @@
 {
-  "open_now_and_closes": "SV: Auki tällä hetkellä, sulkeutuu",
-  "closed_now_and_opens": "SV: Kiinni tällä hetkellä, aukeaa"
+  "open_now_and_closes": "Har öppet för tillfället, stängs",
+  "closed_now_and_opens": "Har stängt för tillfället, öppnas"
 }

--- a/public/locales/sv/venue_page.json
+++ b/public/locales/sv/venue_page.json
@@ -17,9 +17,9 @@
   "share_sport": "Dela motion",
   "map_box.title": "Läge",
   "map_box.accessibility_sentences": "Information om tillgängligheten",
-  "other_sports_section.title": "SV: Muuta samankaltaista liikuntaa",
-  "back_to_venue_page_aria_label": "SV: Takaisin liikuntapaikkasivulle",
-  "a11y_keywords_group_name": "SV: Asiasanat",
-  "show_long_price": "SV: Näytä kaikki",
-  "hide_long_price": "SV: Piilota"
+  "other_sports_section.title": "Annan likadan motion",
+  "back_to_venue_page_aria_label": "Tillbaka till motionsplatssidan",
+  "a11y_keywords_group_name": "Ämnesord",
+  "show_long_price": "Visa alla",
+  "hide_long_price": "Dölj"
 }


### PR DESCRIPTION
## Description

I've updated the missing translations into the CMS and fetched them into the source code.

I checked that there were no untranslated strings in the application currently by searching over the translations for `EN` and `SV`

## Issues

### Closes

**[LIIKUNTA-264](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-264)**
