### PR TITLE
LIIKUNTA-272, LIIKUNTA-273 | Add feedback link to footer and fix spelling mistake in venue page

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,3 +1,4 @@
 {
-  "site_name": "Sports Helsinki"
+  "site_name": "Sports Helsinki",
+  "opens_in_new_tab": "Opens in a new tab"
 }

--- a/public/locales/en/footer.json
+++ b/public/locales/en/footer.json
@@ -2,5 +2,6 @@
   "copyright_text": "All rights reserved",
   "about_us": "About the service",
   "accessibility_statement": "Accessibility statement",
-  "copyright_holder": "City of Helsinki"
+  "copyright_holder": "City of Helsinki",
+  "feedback": "Give feedback"
 }

--- a/public/locales/en/info_block.json
+++ b/public/locales/en/info_block.json
@@ -1,3 +1,0 @@
-{
-  "link.opens_in_new_tab": "Opens in a new tab"
-}

--- a/public/locales/en/map_box.json
+++ b/public/locales/en/map_box.json
@@ -1,4 +1,3 @@
 {
-  "open_map": "Open map",
-  "opens_in_new_tab": "Opens in a new tab"
+  "open_map": "Open map"
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -1,3 +1,4 @@
 {
-  "site_name": "Liikunta Helsinki"
+  "site_name": "Liikunta Helsinki",
+  "opens_in_new_tab": "Avautuu uudessa välilehdessä"
 }

--- a/public/locales/fi/footer.json
+++ b/public/locales/fi/footer.json
@@ -2,5 +2,6 @@
   "copyright_text": "Kaikki oikeudet pidätetään",
   "about_us": "Tietoa palvelusta",
   "accessibility_statement": "Saavutettavuusseloste",
-  "copyright_holder": "Helsingin kaupunki"
+  "copyright_holder": "Helsingin kaupunki",
+  "feedback": "Anna palautetta"
 }

--- a/public/locales/fi/info_block.json
+++ b/public/locales/fi/info_block.json
@@ -1,3 +1,0 @@
-{
-  "link.opens_in_new_tab": "Avautuu uudessa välilehdessä"
-}

--- a/public/locales/fi/map_box.json
+++ b/public/locales/fi/map_box.json
@@ -1,4 +1,3 @@
 {
-  "open_map": "Avaa kartta",
-  "opens_in_new_tab": "Avautuu uudessa välilehdessä"
+  "open_map": "Avaa kartta"
 }

--- a/public/locales/fi/upcoming_events_section.json
+++ b/public/locales/fi/upcoming_events_section.json
@@ -1,3 +1,3 @@
 {
-  "title": "Seuravat tapahtumat"
+  "title": "Seuraavat tapahtumat"
 }

--- a/public/locales/sv/common.json
+++ b/public/locales/sv/common.json
@@ -1,3 +1,4 @@
 {
-  "site_name": "Idrott och motion Helsingfors"
+  "site_name": "Idrott och motion Helsingfors",
+  "opens_in_new_tab": "Öppnas i ett nytt mellanblad"
 }

--- a/public/locales/sv/footer.json
+++ b/public/locales/sv/footer.json
@@ -2,5 +2,6 @@
   "copyright_text": "Alla rättigheter förbehållna",
   "about_us": "Information om tjänsten",
   "accessibility_statement": "Tillgänglighetsutlåtande",
-  "copyright_holder": "Helsingfors stad"
+  "copyright_holder": "Helsingfors stad",
+  "feedback": "Ge respons"
 }

--- a/public/locales/sv/info_block.json
+++ b/public/locales/sv/info_block.json
@@ -1,3 +1,0 @@
-{
-  "link.opens_in_new_tab": "Öppnas i ett nytt mellanblad"
-}

--- a/public/locales/sv/map_box.json
+++ b/public/locales/sv/map_box.json
@@ -1,4 +1,3 @@
 {
-  "open_map": "Öppna kartan",
-  "opens_in_new_tab": "Öppnas i ett nytt mellanblad"
+  "open_map": "Öppna kartan"
 }

--- a/src/common/components/footer/Footer.tsx
+++ b/src/common/components/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { Footer as HDSFooter, LogoLanguage } from "hds-react";
+import { Footer as HDSFooter, IconLinkExternal, LogoLanguage } from "hds-react";
 import React from "react";
 import { useTranslation } from "next-i18next";
 
@@ -10,13 +10,24 @@ import styles from "./footer.module.scss";
 type LinkProps = React.HTMLProps<HTMLAnchorElement> & {
   locale?: React.ComponentProps<typeof NextLink>["locale"];
   lang?: string;
+  external?: boolean;
   children?: React.ReactNode;
 };
 
-const Link = ({ href, children, locale, ...rest }: LinkProps) => {
+const Link = ({
+  href,
+  children,
+  locale,
+  external = false,
+  ...rest
+}: LinkProps) => {
+  const { t } = useTranslation();
   return (
     <NextLink href={href} locale={locale}>
-      <a {...rest}>{children}</a>
+      <a {...rest}>
+        {children}
+        {external && <IconLinkExternal aria-label={t("opens_in_new_tab")} />}
+      </a>
     </NextLink>
   );
 };
@@ -38,6 +49,12 @@ function Footer({ navigationItems }: Props) {
       logoLanguage={logoLanguage}
     >
       <HDSFooter.Navigation variant="minimal">
+        <HDSFooter.Item
+          href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute"
+          label="Anna palautetta"
+          external
+          as={Link}
+        />
         {navigationItems.map((navigationItem) => (
           <HDSFooter.Item
             key={navigationItem.id}

--- a/src/common/components/footer/Footer.tsx
+++ b/src/common/components/footer/Footer.tsx
@@ -51,7 +51,7 @@ function Footer({ navigationItems }: Props) {
       <HDSFooter.Navigation variant="minimal">
         <HDSFooter.Item
           href="https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute"
-          label="Anna palautetta"
+          label={t("feedback")}
           external
           as={Link}
         />

--- a/src/common/components/footer/footer.module.scss
+++ b/src/common/components/footer/footer.module.scss
@@ -12,6 +12,11 @@
     width: 100%;
   }
 
+  // align links to be on the same level with external icon
+  a {
+    align-self: center;
+  }
+
   // fix "back to top" button positioning being slightly off
   @include breakpoints.respond-above(s) {
     > div > div > div > button {

--- a/src/common/components/infoBlock/InfoBlock.tsx
+++ b/src/common/components/infoBlock/InfoBlock.tsx
@@ -70,7 +70,7 @@ function InfoBlockLink({
   label,
   href,
 }: InfoBlockContentLinkProps) {
-  const { t } = useTranslation("info_block");
+  const { t } = useTranslation("common");
 
   if (external) {
     return (
@@ -80,7 +80,7 @@ function InfoBlockLink({
         rel="noreferrer noopener"
         target="_blank"
       >
-        {label} <IconLinkExternal aria-label={t("link.opens_in_new_tab")} />
+        {label} <IconLinkExternal aria-label={t("opens_in_new_tab")} />
       </a>
     );
   }

--- a/src/domain/i18n/serverSideTranslationsWithCommon.ts
+++ b/src/domain/i18n/serverSideTranslationsWithCommon.ts
@@ -7,7 +7,6 @@ const COMMON_TRANSLATIONS = [
   "navigation",
   "footer",
   "card",
-  "info_block",
   "date_time_picker",
   "geolocation_provider",
   "toast",

--- a/src/tests/initI18n.ts
+++ b/src/tests/initI18n.ts
@@ -10,7 +10,6 @@ import footer from "../../public/locales/fi/footer.json";
 import geolocation_provider from "../../public/locales/fi/geolocation_provider.json";
 import hardcoded_shortcuts from "../../public/locales/fi/hardcoded_shortcuts.json";
 import home_page from "../../public/locales/fi/home_page.json";
-import info_block from "../../public/locales/fi/info_block.json";
 import landing_page_search_form from "../../public/locales/fi/landing_page_search_form.json";
 import map_box from "../../public/locales/fi/map_box.json";
 import map_view from "../../public/locales/fi/map_view.json";
@@ -36,7 +35,6 @@ const translation = {
   geolocation_provider,
   hardcoded_shortcuts,
   home_page,
-  info_block,
   landing_page_search_form,
   map_box,
   map_view,


### PR DESCRIPTION
## Description

- Add feedback link to footer (move "opens in a new tab" translation to common)
- Fix spelling mistake in venue pages "Next events" finnish title

## Issues

### Closes

**[LIIKUNTA-272](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-272):**
**[LIIKUNTA-273](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-273):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots

<img width="942" alt="Screenshot 2022-02-10 at 10 45 36" src="https://user-images.githubusercontent.com/15219142/153370432-aebb09e5-fddd-4df4-b970-166013d938bb.png">


## Additional notes
