### PR TITLE
LIIKUNTA-286 | Fix instance for public facing production domain

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -29,7 +29,7 @@ env:
   SENTRY_AUTH_TOKEN: ${{ secrets.GH_SENTRY_AUTH_TOKEN }}
   NEXT_PUBLIC_CMS_GRAPHQL_ENDPOINT: https://liikunta.content.api.hel.fi/graphql
   NEXT_PUBLIC_UNIFIED_SEARCH_GRAPHQL_ENDPOINT: https://unified-search.prod.kuva.hel.ninja/search
-  NEXT_PUBLIC_NEXT_API_GRAPHQL_ENDPOINT: https://${{ secrets.ENVIRONMENT_URL_STABLE }}/api/graphql
+  NEXT_PUBLIC_NEXT_API_GRAPHQL_ENDPOINT: https://liikunta.hel.fi/api/graphql
   NEXT_PUBLIC_MATOMO_SITE_ID: 587
   NEXT_PUBLIC_MATOMO_ENABLED: 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+
+## [Unreleased]
+
+### Fixed
+
+- Configured production environment to work from https://liikunta.hel.fi

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 Test: https://liikunta-helsinki.test.kuva.hel.ninja/
 
-Production: https://liikunta-helsinki.prod.kuva.hel.ninja/
+Production: https://liikunta.hel.fi
 
 ## Links
 


### PR DESCRIPTION
## Description

Problem was that https://liikunta-helsinki.prod.kuva.hel.ninja didn't allow request from the new public facing production domain.

Fix here is to make the request into an endpoint in the same origin so that the browser doesn't complain about CORS.

Configures the instance in the production environment to work with the public facing domain name. After this change, the version with the private domain name will not work.

This is somewhat quick and dirty.

Other fixes:

- Disable CORS (https://github.com/vercel/next.js/tree/canary/examples/api-routes-cors)
- Allow both production domains (https://stackoverflow.com/a/59600058)

## Issues

### Closes

**[LIIKUNTA-286](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-286):**
