### PR TITLE
LIIKUNTA-282 | Fix viewport overflow issues on small mobile screens

### DIFF
--- a/src/common/components/card/card.module.scss
+++ b/src/common/components/card/card.module.scss
@@ -13,11 +13,12 @@
   }
 
   display: grid;
-  grid-template-columns: var(--width-image) 1fr auto;
-  grid-template-rows: min-content auto;
+  grid-template-columns: var(--width-image) 1fr;
+  grid-template-rows: min-content 1fr auto;
   grid-template-areas:
-    "bg keywords cta"
-    "bg text cta";
+    "bg keywords"
+    "bg text"
+    "bg cta";
   height: 100%;
   width: 100%;
 
@@ -212,14 +213,15 @@
 
   .cta {
     align-self: center;
-    display: flex;
-    height: 2.5rem;
-    width: 2.5rem;
-    padding: 0;
-    margin: 0 var(--content-padding) 0 0;
+
     display: flex;
     justify-content: center;
     align-items: center;
+
+    height: 2.5rem;
+    width: 2.5rem;
+    padding: 0;
+    margin: 0 var(--content-padding) var(--content-padding);
 
     color: var(--color-black);
 

--- a/src/common/components/hero/hero.module.scss
+++ b/src/common/components/hero/hero.module.scss
@@ -2,15 +2,20 @@
 @import "variables";
 
 .box {
+  --width: 100%;
+  --max-width: 20rem;
+
   grid-row: 1;
   align-self: center;
   background-color: rgba($color-black, 70%);
-  width: 20rem;
+  width: var(--width);
+  max-width: var(--max-width);
   margin-bottom: 10rem;
   padding: $spacing-m;
 
   @include breakpoints.respond-above(m) {
-    width: 30rem;
+    --width: 30rem;
+    --max-width: unset;
   }
 }
 

--- a/src/common/components/list/list.module.scss
+++ b/src/common/components/list/list.module.scss
@@ -61,7 +61,7 @@
 .fixed-grid-4 {
   display: grid;
 
-  @include breakpoints.respond-above(xs) {
+  @include breakpoints.respond-above(m) {
     grid-template-columns: 1fr 1fr;
 
     & > * {

--- a/src/common/components/list/list.module.scss
+++ b/src/common/components/list/list.module.scss
@@ -8,7 +8,7 @@
   padding: 0;
   display: grid;
   grid-template-columns:
-    [column-start] repeat(auto-fit, minmax(var(--base-list-item-width), 1fr))
+    [column-start] repeat(auto-fit, minmax(1fr, var(--base-list-item-width)))
     [column-end];
   grid-gap: $spacing-xs;
 


### PR DESCRIPTION
## Description

Previously the content of the index page would overflow its container on small screens.

After this change, elements have been adjusted so that they can be scaled on small screens.

You should see scroll bras on staging when using a screen size of 320px. Those scroll bars should be missing in this PR.

Reproducing the issue wit Chrome was difficult. It was easier to do with for instance Safari.

On Chrome you need to set the viewport to 320, click within the viewport, zoom with ctrl+ and the reset zoom with ctrl+0.

## Issues

### Closes

**[LIIKUNTA-282](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-282)**

## Screenshots

<img width="551" alt="Screenshot 2022-04-13 at 9 47 13" src="https://user-images.githubusercontent.com/9090689/163116835-7235d54a-a5d4-40d1-8470-01f1a92e45c1.png">
<img width="551" alt="Screenshot 2022-04-13 at 9 47 17" src="https://user-images.githubusercontent.com/9090689/163116843-37282f2d-9ef2-4855-b50f-cea47f764efc.png">

