### PR TITLE
LIIKUNTA-287: Card keywords z-index fix

### DIFF
--- a/src/common/components/card/card.module.scss
+++ b/src/common/components/card/card.module.scss
@@ -139,7 +139,7 @@
     align-items: flex-end;
     flex-wrap: wrap;
     position: relative;
-    z-index: 100;
+    z-index: 1;
     height: max-content;
     align-self: flex-end;
 


### PR DESCRIPTION
## Description
Fix for keywords overlapping the dropdown values.

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots
<img width="940" alt="image" src="https://user-images.githubusercontent.com/16116141/163145614-60f59bee-2434-490c-b802-a50b8f3b3493.png">


## Additional notes
