### PR TITLE
LIIKUNTA-267: Add contact information from connections

### DIFF
--- a/public/locales/en/venue_page.json
+++ b/public/locales/en/venue_page.json
@@ -19,5 +19,6 @@
   "back_to_venue_page_aria_label": "Back to the sports location page",
   "a11y_keywords_group_name": "Key words",
   "show_long_price": "Show all",
-  "hide_long_price": "Hide"
+  "hide_long_price": "Hide",
+  "block.contact_details.label": "Contact information"
 }

--- a/public/locales/fi/venue_page.json
+++ b/public/locales/fi/venue_page.json
@@ -19,5 +19,6 @@
   "back_to_venue_page_aria_label": "Takaisin liikuntapaikkasivulle",
   "a11y_keywords_group_name": "Asiasanat",
   "show_long_price": "Näytä kaikki",
-  "hide_long_price": "Piilota"
+  "hide_long_price": "Piilota",
+  "block.contact_details.label": "Yhteystiedot"
 }

--- a/public/locales/sv/venue_page.json
+++ b/public/locales/sv/venue_page.json
@@ -19,5 +19,6 @@
   "back_to_venue_page_aria_label": "Tillbaka till motionsplatssidan",
   "a11y_keywords_group_name": "Ämnesord",
   "show_long_price": "Visa alla",
-  "hide_long_price": "Dölj"
+  "hide_long_price": "Dölj",
+  "block.contact_details.label": "Kontaktuppgifter"
 }

--- a/src/__tests__/venues/__mocks__/[id].tsx
+++ b/src/__tests__/venues/__mocks__/[id].tsx
@@ -37,16 +37,19 @@ export const defaultConnections = [
     __typename: "Connection",
     sectionType: "PHONE_OR_EMAIL",
     name: "Kassa",
+    phone: "+3581234567",
   },
   {
     __typename: "Connection",
     sectionType: "PHONE_OR_EMAIL",
     name: "Liikunnanohjaus",
+    phone: "+3581234568",
   },
   {
     __typename: "Connection",
     sectionType: "PHONE_OR_EMAIL",
     name: "Tiimiesihenkilö",
+    phone: "+35812345679",
   },
   {
     __typename: "Connection",

--- a/src/domain/graphql/__tests__/__snapshots__/graphqlEndpointIntegration.test.js.snap
+++ b/src/domain/graphql/__tests__/__snapshots__/graphqlEndpointIntegration.test.js.snap
@@ -37,18 +37,22 @@ Object {
       "connections": Array [
         Object {
           "name": "Päiväkodinjohtaja",
+          "phone": "+358 9 310 64132",
           "sectionType": "PHONE_OR_EMAIL",
         },
         Object {
           "name": "Hakemus kerhotoimintaan, esiopetukseen ja esiopetusta täydentävään varhaiskasvatukseen",
+          "phone": null,
           "sectionType": "ESERVICE_LINK",
         },
         Object {
           "name": "Kerhohakemus sähköisessä asioinnissa",
+          "phone": null,
           "sectionType": "ESERVICE_LINK",
         },
         Object {
           "name": "Varhaiskasvatushakemus Asti-asiointipalvelussa",
+          "phone": null,
           "sectionType": "ESERVICE_LINK",
         },
       ],
@@ -209,18 +213,22 @@ Object {
         "connections": Array [
           Object {
             "name": "Päiväkodinjohtaja",
+            "phone": "+358 9 310 64132",
             "sectionType": "PHONE_OR_EMAIL",
           },
           Object {
             "name": "Hakemus kerhotoimintaan, esiopetukseen ja esiopetusta täydentävään varhaiskasvatukseen",
+            "phone": null,
             "sectionType": "ESERVICE_LINK",
           },
           Object {
             "name": "Kerhohakemus sähköisessä asioinnissa",
+            "phone": null,
             "sectionType": "ESERVICE_LINK",
           },
           Object {
             "name": "Varhaiskasvatushakemus Asti-asiointipalvelussa",
+            "phone": null,
             "sectionType": "ESERVICE_LINK",
           },
         ],
@@ -351,18 +359,22 @@ Object {
         "connections": Array [
           Object {
             "name": "Päiväkodinjohtaja",
+            "phone": "+358 9 310 64132",
             "sectionType": "PHONE_OR_EMAIL",
           },
           Object {
             "name": "Hakemus kerhotoimintaan, esiopetukseen ja esiopetusta täydentävään varhaiskasvatukseen",
+            "phone": null,
             "sectionType": "ESERVICE_LINK",
           },
           Object {
             "name": "Kerhohakemus sähköisessä asioinnissa",
+            "phone": null,
             "sectionType": "ESERVICE_LINK",
           },
           Object {
             "name": "Varhaiskasvatushakemus Asti-asiointipalvelussa",
+            "phone": null,
             "sectionType": "ESERVICE_LINK",
           },
         ],

--- a/src/domain/graphql/__tests__/graphqlEndpointIntegration.test.js
+++ b/src/domain/graphql/__tests__/graphqlEndpointIntegration.test.js
@@ -65,6 +65,7 @@ const GET_VENUE = gql`
       connections {
         sectionType
         name
+        phone
       }
     }
   }
@@ -132,6 +133,7 @@ const GET_VENUES_BY_IDS = gql`
       connections {
         sectionType
         name
+        phone
       }
     }
   }

--- a/src/domain/graphql/venue/instructions/VenueTprekIntegration.ts
+++ b/src/domain/graphql/venue/instructions/VenueTprekIntegration.ts
@@ -60,6 +60,7 @@ export type TprekUnit = {
     name_fi: string;
     name_en: string;
     name_sv: string;
+    phone: string;
   }>;
   ontologyword_details: TprekUnitOntologywordDetails[];
   service_descriptions: TprekUnitServiceDescriptions[];
@@ -106,6 +107,7 @@ export default class VenueTprekIntegration extends VenueResolverIntegration<Tpre
       connections: data?.connections?.map((connection) => ({
         sectionType: connection.section_type,
         name: formTranslationObject(connection, "name"),
+        phone: connection.phone,
       })),
     };
   }

--- a/src/domain/graphql/venue/venueSchema.ts
+++ b/src/domain/graphql/venue/venueSchema.ts
@@ -69,6 +69,7 @@ const createVenueSchema = ({ haukiEnabled }: LiikuntaServerConfig = {}) => gql`
   type Connection {
     sectionType: String
     name: String
+    phone: String
   }
 
   type Venue {

--- a/src/pages/venues/[id]/index.tsx
+++ b/src/pages/venues/[id]/index.tsx
@@ -8,6 +8,7 @@ import {
   IconMap,
   IconAngleDown,
   IconTicket,
+  IconPhone,
 } from "hds-react";
 import React from "react";
 import classNames from "classnames";
@@ -86,6 +87,7 @@ export const VENUE_QUERY = gql`
       connections {
         sectionType
         name
+        phone
       }
     }
   }
@@ -313,6 +315,14 @@ export function VenuePageContent() {
   const connectionOpeningHoursSectionsLines =
     connectionOpeningHoursSectionsContents.join("\n\n").split("\n");
 
+  const contactDetailsSectionsContents = data?.venue?.connections?.filter(
+    (item) => item.sectionType === "PHONE_OR_EMAIL"
+  );
+
+  const hasContactDetails = Boolean(
+    email || telephone || contactDetailsSectionsContents?.length > 0
+  );
+
   // Data that can't be found from the API at this point
   const temperature = null;
   const organizer = null;
@@ -401,15 +411,30 @@ export function VenuePageContent() {
                 ]}
               />
             )}
+            {hasContactDetails && (
+              <InfoBlock
+                headingLevel="h3"
+                icon={<IconPhone aria-hidden="true" />}
+                name={t("block.contact_details.label")}
+                contents={[
+                  <InfoBlock.List
+                    key="contact-details-main"
+                    items={[telephone, email]}
+                  />,
+                  ...contactDetailsSectionsContents?.map((contact, i) => (
+                    <InfoBlock.List
+                      key={`contact-details-other-${i}`}
+                      items={[contact.name, contact.phone]}
+                    />
+                  )),
+                ]}
+              />
+            )}
             <InfoBlock
               headingLevel="h3"
               icon={<IconInfoCircle aria-hidden="true" />}
               name={t("block.other_information.label")}
               contents={[
-                <InfoBlock.List
-                  key="contact-details"
-                  items={[telephone, email]}
-                />,
                 <InfoBlock.List
                   key="social-media-links"
                   items={links.reduce((acc, link) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,6 +208,7 @@ export type VenueDetails<T = TranslationsObject> = {
   connections: Array<{
     sectionType: string;
     name: T;
+    phone: string;
   }>;
 };
 


### PR DESCRIPTION
## Description

The contact information of the venue moved from Other details section to separate Contact information section. The contact information is extended with connections contact details data

## Issues

### Closes

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related

## Testing

### Automated tests

### Manual testing

## Screenshots
<img width="303" alt="image" src="https://user-images.githubusercontent.com/16116141/163167936-c95e8953-c2f0-45a1-9da9-51d1c0c40a0d.png">


## Additional notes
