### PR TITLE
LIIKUNTA-282 | Fix list grids on bigger screen sizes

### DIFF
--- a/src/common/components/list/list.module.scss
+++ b/src/common/components/list/list.module.scss
@@ -2,7 +2,7 @@
 @import "variables";
 
 .list {
-  --base-list-item-width: 22rem; // 256px
+  --base-list-item-width: 18rem;
 
   margin: 0;
   padding: 0;

--- a/src/common/components/list/list.module.scss
+++ b/src/common/components/list/list.module.scss
@@ -8,7 +8,7 @@
   padding: 0;
   display: grid;
   grid-template-columns:
-    [column-start] repeat(auto-fit, minmax(1fr, var(--base-list-item-width)))
+    [column-start] repeat(auto-fit, minmax(var(--base-list-item-width), 1fr))
     [column-end];
   grid-gap: $spacing-xs;
 


### PR DESCRIPTION
## Description

The previous fix broke lists on bigger screen.

This alternative fix decreases grid minimum cell width on small screens so that lists can fit 320px screen sizes.

## Issues

### Closes

**[LIIKUNTA-282](https://helsinkisolutionoffice.atlassian.net/browse/LIIKUNTA-282)**