### PR TITLE
Document release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.1.0] - 2022-04-20
+
 ### Fixed
 
 - Missing images on collection page for venue selections
 - A11y: When advising about external links, or links that open in a new tab, include the info text by using aria-label
+- A11y: Page scales for window size with the width of 320px
+- Keyword overflow on search page
+
+### Added
+
+- Social links under other details on single location page
+
+### Removed
+
+- Location section from single location page sidebar
 
 ### Changed
 
 - Let app know about its origin instead of its graphql endpoint
+- Separate 'contact information' and 'other info' sections in single location page sidebar
+- Limit collection description text to maximum of three rows
+- Increase size of collection description text
 
 ## [1.0.0] - 2022-03-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liikunta-helsinki",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## [1.1.0] - 2022-04-20

### Fixed

- Missing images on collection page for venue selections
- A11y: When advising about external links, or links that open in a new tab, include the info text by using aria-label
- A11y: Page scales for window size with the width of 320px
- Keyword overflow on search page

### Added

- Social links under other details on single location page

### Removed

- Location section from single location page sidebar

### Changed

- Let app know about its origin instead of its graphql endpoint
- Separate 'contact information' and 'other info' sections in single location page sidebar
- Limit collection description text to maximum of three rows
- Increase size of collection description text